### PR TITLE
Improve agent call logging and LangSmith tracing (#4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ requires-python = ">=3.12"
 dependencies = [
     "langchain",
     "langgraph",
+    "langsmith>=0.7",
     "httpx",
+    "rich>=13",
     "pydantic>=2",
     "pydantic-settings",
     "python-dotenv>=1",

--- a/src/juno/agents/build_mercury_subagent.py
+++ b/src/juno/agents/build_mercury_subagent.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Annotated, Any
+
 
 from langchain.agents import create_agent
 from langchain.tools import InjectedState, tool
@@ -15,6 +17,9 @@ from juno.agents.remote_guide_middleware import build_remote_invoke_guide_middle
 from juno.agents.state import CustomAgentState
 from juno.assistants.loader import AssistantManifest
 from juno.assistants.mercury_runner import MercuryAssistantRunner
+from juno.logging_config import get_trace_id
+
+logger = logging.getLogger(__name__)
 
 
 def _normalize_approval_response(raw: Any) -> dict[str, Any] | None:
@@ -128,15 +133,31 @@ def build_mercury_subagent(
         try:
             intent = json.loads(intent_json)
         except json.JSONDecodeError as exc:
+            logger.info(
+                "phase=mercury_invoke_invalid_json trace_id=%s error=%s",
+                get_trace_id(),
+                exc,
+            )
             return f"Invalid intent JSON: {exc}"
         if not isinstance(intent, dict):
+            logger.info("phase=mercury_invoke_invalid trace_id=%s reason=not_object", get_trace_id())
             return "Intent must be a JSON object."
         if intent.get("kind") is None:
+            logger.info("phase=mercury_invoke_invalid trace_id=%s reason=missing_kind", get_trace_id())
             return 'Intent must include a string "kind" field.'
         intent_clean, idempotency_key = _sanitize_intent_for_mercury_post(intent)
         payload = _build_mercury_invoke_payload(state, intent_clean)
         result = runner.run_turn(payload, idempotency_key=idempotency_key)
-        return turn_result_to_tool_text(result)
+        text = turn_result_to_tool_text(result)
+        logger.info(
+            "phase=mercury_invoke_done trace_id=%s intent_kind=%s idempotency=%s result_kind=%s tool_text_len=%s",
+            get_trace_id(),
+            intent_clean.get("kind"),
+            idempotency_key is not None,
+            getattr(result, "kind", type(result).__name__),
+            len(text),
+        )
+        return text
 
     guide_path = (manifest.guide_path or "").strip()
     middleware: tuple[Any, ...] = ()

--- a/src/juno/agents/build_supervisor.py
+++ b/src/juno/agents/build_supervisor.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import time
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -17,6 +19,9 @@ from langgraph.graph.state import CompiledStateGraph
 
 from juno.agents.registry import SubagentSpec
 from juno.agents.state import CustomAgentState
+from juno.logging_config import get_trace_id
+
+logger = logging.getLogger(__name__)
 
 _ENV_SUPERVISOR_PROMPT_PATH = "JUNO_SUPERVISOR_PROMPT_PATH"
 _DEFAULT_SUPERVISOR_PROMPT_REL = Path("config") / "juno.supervisor.md"
@@ -104,6 +109,21 @@ def _create_subagent_tool(spec: SubagentSpec) -> BaseTool:
 
     @tool(spec.name, description=spec.description)
     def _delegate(request: str, runtime: ToolRuntime) -> str:
+        tid = get_trace_id()
+        preview = request if len(request) <= 200 else request[:200] + "…"
+        logger.info(
+            "phase=subagent_delegate_start trace_id=%s subagent=%s request_len=%s",
+            tid,
+            spec.name,
+            len(request),
+        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "phase=subagent_delegate_preview trace_id=%s subagent=%s preview=%r",
+                tid,
+                spec.name,
+                preview,
+            )
         st = runtime.state
         sub_msgs: list[Any] = [HumanMessage(content=request)]
         if resume is not None and st.get("approval_response") is not None:
@@ -112,7 +132,16 @@ def _create_subagent_tool(spec: SubagentSpec) -> BaseTool:
         for key in keys:
             if key in st and st[key] is not None:
                 sub_input[key] = st[key]
-        out = graph.invoke(sub_input, runtime.config)
+        t0 = time.perf_counter()
+        try:
+            out = graph.invoke(sub_input, runtime.config)
+        finally:
+            logger.info(
+                "phase=subagent_delegate_end trace_id=%s subagent=%s duration_ms=%.1f",
+                tid,
+                spec.name,
+                (time.perf_counter() - t0) * 1000.0,
+            )
         msgs = out.get("messages", [])
         return _final_ai_content(msgs)
 

--- a/src/juno/assistants/mercury_runner.py
+++ b/src/juno/assistants/mercury_runner.py
@@ -24,10 +24,13 @@ or inner dict (nested mode).
 from __future__ import annotations
 
 import json
+import logging
+import time
 import uuid
 from typing import Any, Literal
 
 import httpx
+from langsmith import traceable
 
 from juno.assistants.protocol import (
     AssistantTurnAgentError,
@@ -35,6 +38,37 @@ from juno.assistants.protocol import (
     AssistantTurnResult,
     parse_mercury_body,
 )
+from juno.logging_config import get_trace_id
+
+logger = logging.getLogger(__name__)
+
+
+def _intent_kind_from_payload(payload: dict[str, Any]) -> str | None:
+    intent = payload.get("intent")
+    if isinstance(intent, dict) and intent.get("kind") is not None:
+        return str(intent.get("kind"))
+    return None
+
+
+def _response_to_result(response: httpx.Response) -> AssistantTurnResult:
+    if response.status_code >= 400:
+        return _map_http_error(response)
+    try:
+        data = response.json()
+    except json.JSONDecodeError:
+        return AssistantTurnAgentError(
+            message="Response body was not valid JSON",
+            code="invalid_json",
+            details={"body_snippet": _body_snippet(response.text)},
+        )
+    if not isinstance(data, dict):
+        return AssistantTurnAgentError(
+            message="Mercury JSON root must be an object",
+            code="invalid_shape",
+            details={"got_type": type(data).__name__},
+        )
+    return parse_mercury_body(data)
+
 
 def _json_body_for_request(
     payload: dict[str, Any],
@@ -119,6 +153,16 @@ class MercuryAssistantRunner:
         *,
         idempotency_key: str | None = None,
     ) -> AssistantTurnResult:
+        return _traced_mercury_run_turn(self, payload, idempotency_key=idempotency_key)
+
+    def _execute_sync_turn(
+        self,
+        payload: dict[str, Any],
+        *,
+        idempotency_key: str | None,
+    ) -> AssistantTurnResult:
+        tid = get_trace_id()
+        kind = _intent_kind_from_payload(payload)
         url = f"{self.base_url}{self._http_path}"
         body = _json_body_for_request(
             payload,
@@ -127,25 +171,28 @@ class MercuryAssistantRunner:
         )
         rid = str(uuid.uuid4()) if self._send_x_request_id else None
         headers = _headers(idempotency_key=idempotency_key, x_request_id=rid)
+        logger.info(
+            "phase=mercury_http_start trace_id=%s path=%s x_request_id=%s intent_kind=%s idempotency=%s",
+            tid,
+            self._http_path,
+            rid,
+            kind,
+            idempotency_key is not None,
+        )
+        t0 = time.perf_counter()
         with httpx.Client(timeout=self.timeout_s, transport=self._transport) as client:
             response = client.post(url, json=body, headers=headers)
-        if response.status_code >= 400:
-            return _map_http_error(response)
-        try:
-            data = response.json()
-        except json.JSONDecodeError:
-            return AssistantTurnAgentError(
-                message="Response body was not valid JSON",
-                code="invalid_json",
-                details={"body_snippet": _body_snippet(response.text)},
-            )
-        if not isinstance(data, dict):
-            return AssistantTurnAgentError(
-                message="Mercury JSON root must be an object",
-                code="invalid_shape",
-                details={"got_type": type(data).__name__},
-            )
-        return parse_mercury_body(data)
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+        result = _response_to_result(response)
+        rkind = getattr(result, "kind", type(result).__name__)
+        logger.info(
+            "phase=mercury_http_end trace_id=%s duration_ms=%.1f http_status=%s result_kind=%s",
+            tid,
+            elapsed_ms,
+            response.status_code,
+            rkind,
+        )
+        return result
 
     async def arun_turn(
         self,
@@ -153,6 +200,8 @@ class MercuryAssistantRunner:
         *,
         idempotency_key: str | None = None,
     ) -> AssistantTurnResult:
+        tid = get_trace_id()
+        kind = _intent_kind_from_payload(payload)
         url = f"{self.base_url}{self._http_path}"
         body = _json_body_for_request(
             payload,
@@ -161,25 +210,37 @@ class MercuryAssistantRunner:
         )
         rid = str(uuid.uuid4()) if self._send_x_request_id else None
         headers = _headers(idempotency_key=idempotency_key, x_request_id=rid)
+        logger.info(
+            "phase=mercury_http_async_start trace_id=%s path=%s x_request_id=%s intent_kind=%s",
+            tid,
+            self._http_path,
+            rid,
+            kind,
+        )
+        t0 = time.perf_counter()
         async with httpx.AsyncClient(timeout=self.timeout_s, transport=self._transport) as client:
             response = await client.post(url, json=body, headers=headers)
-        if response.status_code >= 400:
-            return _map_http_error(response)
-        try:
-            data = response.json()
-        except json.JSONDecodeError:
-            return AssistantTurnAgentError(
-                message="Response body was not valid JSON",
-                code="invalid_json",
-                details={"body_snippet": _body_snippet(response.text)},
-            )
-        if not isinstance(data, dict):
-            return AssistantTurnAgentError(
-                message="Mercury JSON root must be an object",
-                code="invalid_shape",
-                details={"got_type": type(data).__name__},
-            )
-        return parse_mercury_body(data)
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+        result = _response_to_result(response)
+        rkind = getattr(result, "kind", type(result).__name__)
+        logger.info(
+            "phase=mercury_http_async_end trace_id=%s duration_ms=%.1f http_status=%s result_kind=%s",
+            tid,
+            elapsed_ms,
+            response.status_code,
+            rkind,
+        )
+        return result
+
+
+@traceable(run_type="tool", name="mercury_http")
+def _traced_mercury_run_turn(
+    runner: MercuryAssistantRunner,
+    payload: dict[str, Any],
+    *,
+    idempotency_key: str | None = None,
+) -> AssistantTurnResult:
+    return runner._execute_sync_turn(payload, idempotency_key=idempotency_key)
 
 
 __all__ = ["MercuryAssistantRunner"]

--- a/src/juno/logging_config.py
+++ b/src/juno/logging_config.py
@@ -1,0 +1,68 @@
+"""Process-wide logging: Rich colored console, optional plain mode, trace id context."""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import os
+import sys
+from collections.abc import Generator
+from contextlib import contextmanager
+
+juno_trace_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("juno_trace_id", default=None)
+
+
+def get_trace_id() -> str | None:
+    return juno_trace_id_var.get()
+
+
+@contextmanager
+def juno_trace_scope(trace_id: str) -> Generator[None, None, None]:
+    token = juno_trace_id_var.set(trace_id)
+    try:
+        yield
+    finally:
+        juno_trace_id_var.reset(token)
+
+
+def _stderr_color_enabled() -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("JUNO_LOG_COLOR", "").strip().lower() in ("0", "false", "no"):
+        return False
+    return sys.stderr.isatty()
+
+
+def configure_logging() -> None:
+    """Configure root logging once (Rich when TTY and color allowed, else plain StreamHandler)."""
+    level_name = os.environ.get("JUNO_LOG_LEVEL", "INFO").strip().upper() or "INFO"
+    level = getattr(logging, level_name, logging.INFO)
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(level)
+
+    if _stderr_color_enabled():
+        from rich.logging import RichHandler
+
+        handler: logging.Handler = RichHandler(
+            rich_tracebacks=True,
+            show_path=False,
+            markup=False,
+            show_time=True,
+            omit_repeated_times=False,
+        )
+    else:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+
+    handler.setLevel(level)
+    root.addHandler(handler)
+
+
+__all__ = [
+    "configure_logging",
+    "get_trace_id",
+    "juno_trace_id_var",
+    "juno_trace_scope",
+]

--- a/src/juno/telegram/bot.py
+++ b/src/juno/telegram/bot.py
@@ -10,6 +10,7 @@ from telegram import Update
 from telegram.ext import Application, CallbackQueryHandler, CommandHandler, MessageHandler, filters
 
 from juno.identity import JunoIdentityNotFoundError, JunoIdentityValidationError, load_identity
+from juno.logging_config import configure_logging
 from juno.runtime.factory import build_supervisor_bundle
 from juno.settings import Settings
 from juno.telegram.handlers import (
@@ -91,10 +92,7 @@ def main() -> None:
     from dotenv import load_dotenv
 
     load_dotenv()
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    configure_logging()
     asyncio.run(run_bot())
 
 

--- a/src/juno/telegram/turn.py
+++ b/src/juno/telegram/turn.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import time
+import uuid
 from typing import Any
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langgraph.graph.state import CompiledStateGraph
-from telegram import Update
 from telegram.constants import ChatAction
-from telegram.ext import Application, ContextTypes
+from telegram.ext import Application
 
+from juno.logging_config import juno_trace_scope
 from juno.settings import Settings
 from juno.telegram.approval_state import (
     pop_last_approval_token,
@@ -69,10 +71,27 @@ async def invoke_supervisor(
     *,
     use_typing: bool,
 ) -> dict[str, Any]:
+    trace_id = (config.get("metadata") or {}).get("juno_trace_id")
+    logger.info(
+        "phase=supervisor_invoke_start trace_id=%s chat_id=%s typing=%s",
+        trace_id,
+        chat_id,
+        use_typing,
+    )
+    t0 = time.perf_counter()
     fut = asyncio.to_thread(supervisor.invoke, inp, config)
-    if use_typing:
-        return await typing_while(application.bot, chat_id, fut)
-    return await fut
+    try:
+        if use_typing:
+            out = await typing_while(application.bot, chat_id, fut)
+        else:
+            out = await fut
+    finally:
+        logger.info(
+            "phase=supervisor_invoke_end trace_id=%s duration_ms=%.1f",
+            trace_id,
+            (time.perf_counter() - t0) * 1000.0,
+        )
+    return out
 
 
 async def execute_supervisor_turn(
@@ -84,6 +103,8 @@ async def execute_supervisor_turn(
     reply_to_message_id: int | None = None,
 ) -> None:
     """Run one supervisor invoke and send the reply (and optional approval keyboard)."""
+    trace_id = uuid.uuid4().hex
+    user_id = str(user.id) if user else None
     supervisor: CompiledStateGraph = application.bot_data["supervisor"]
     settings: Settings = application.bot_data["settings"]
     sess = get_chat_session(application.bot_data, chat_id)
@@ -95,6 +116,23 @@ async def execute_supervisor_turn(
         approval_val = pending
         had_approval_merge = True
 
+    logger.info(
+        "phase=turn_start trace_id=%s chat_id=%s user_id=%s user_text_len=%s "
+        "had_approval_merge=%s has_approval_in_input=%s",
+        trace_id,
+        chat_id,
+        user_id,
+        len(user_text),
+        had_approval_merge,
+        approval_val is not None,
+    )
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "phase=turn_user_preview trace_id=%s preview=%r",
+            trace_id,
+            (user_text[:80] + "…") if len(user_text) > 80 else user_text,
+        )
+
     messages: list[Any] = []
     if had_approval_merge:
         messages.append(SystemMessage(content=TELEGRAM_AFTER_APPROVE_SYSTEM))
@@ -102,32 +140,51 @@ async def execute_supervisor_turn(
 
     inp: dict[str, Any] = {
         "messages": messages,
-        "user_id": str(user.id) if user else None,
+        "user_id": user_id,
         "wallet_id": sess["wallet_id"],
         "chain": sess["chain"],
     }
     if approval_val is not None:
         inp["approval_response"] = approval_val
 
-    config = {"configurable": {"thread_id": str(chat_id)}}
+    metadata = {
+        "juno_trace_id": trace_id,
+        "telegram_chat_id": chat_id,
+        "telegram_user_id": user_id,
+    }
+    config: dict[str, Any] = {
+        "configurable": {
+            "thread_id": str(chat_id),
+            "juno_trace_id": trace_id,
+        },
+        "metadata": metadata,
+        "tags": ["juno", "telegram"],
+        "run_name": "juno_telegram_turn",
+    }
 
-    try:
-        out = await invoke_supervisor(
-            application,
-            chat_id,
-            supervisor,
-            inp,
-            config,
-            use_typing=settings.juno_use_stream,
-        )
-    except Exception as exc:
-        logger.exception("supervisor.invoke failed")
-        await application.bot.send_message(
-            chat_id=chat_id,
-            text=format_agent_error(exc),
-            reply_to_message_id=reply_to_message_id,
-        )
-        return
+    turn_t0 = time.perf_counter()
+    with juno_trace_scope(trace_id):
+        try:
+            out = await invoke_supervisor(
+                application,
+                chat_id,
+                supervisor,
+                inp,
+                config,
+                use_typing=settings.juno_use_stream,
+            )
+        except Exception as exc:
+            logger.exception(
+                "phase=turn_error trace_id=%s chat_id=%s supervisor.invoke failed",
+                trace_id,
+                chat_id,
+            )
+            await application.bot.send_message(
+                chat_id=chat_id,
+                text=format_agent_error(exc),
+                reply_to_message_id=reply_to_message_id,
+            )
+            return
 
     if had_approval_merge:
         pop_last_approval_token(application.bot_data, chat_id)
@@ -146,12 +203,23 @@ async def execute_supervisor_turn(
             reply_markup=keyboard,
             reply_to_message_id=reply_to_message_id,
         )
+        logger.info(
+            "phase=turn_end trace_id=%s outcome=wallet_approval_keyboard duration_ms=%.1f",
+            trace_id,
+            (time.perf_counter() - turn_t0) * 1000.0,
+        )
         return
 
     await application.bot.send_message(
         chat_id=chat_id,
         text=final_text if final_text.strip() else "(no reply)",
         reply_to_message_id=reply_to_message_id,
+    )
+    logger.info(
+        "phase=turn_end trace_id=%s outcome=reply duration_ms=%.1f reply_len=%s",
+        trace_id,
+        (time.perf_counter() - turn_t0) * 1000.0,
+        len(final_text),
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -303,11 +303,13 @@ dependencies = [
     { name = "langchain-groq" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "langsmith" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
     { name = "pyyaml" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -323,11 +325,13 @@ requires-dist = [
     { name = "langchain-groq" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "langsmith", specifier = ">=0.7" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pydantic-settings" },
     { name = "python-dotenv", specifier = ">=1" },
     { name = "python-telegram-bot", specifier = ">=21" },
     { name = "pyyaml" },
+    { name = "rich", specifier = ">=13" },
 ]
 
 [package.metadata.requires-dev]
@@ -483,6 +487,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/38/092f99a3326f0f6bb6ea62f388b16611d9cb619869ed7b0f3dae6c21c331/langsmith-0.7.37.tar.gz", hash = "sha256:e15ab27f5febbcfbaec4e6fa74ab71f0284f4c5965249cc732fe9344844290cb", size = 4433170, upload-time = "2026-04-26T21:36:41.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/76/fa99559d23ec9a39e1153f317a5ec99e7b967aec08b5faac04f8da603dd3/langsmith-0.7.37-py3-none-any.whl", hash = "sha256:64fc5fbf223fcdcc6ee44b08a5df4b2ab8a55e4d968e850c86b6b69fe0c258e3", size = 385948, upload-time = "2026-04-26T21:36:39.09Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -937,6 +962,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Implements clearer logging and optional LangSmith compatibility for [issue #4](https://github.com/agentic-pantheon/Juno/issues/4).

## Changes
- **Colored console logs**: `juno.logging_config.configure_logging()` uses Rich on TTY; plain formatter when `NO_COLOR` or `JUNO_LOG_COLOR=0` or non-TTY. Level from `JUNO_LOG_LEVEL` (default INFO).
- **Trace correlation**: Each Telegram turn gets a `juno_trace_id` (hex) in logs and in LangGraph `RunnableConfig` (`metadata`, `configurable`, `tags`, `run_name`). `juno_trace_scope` propagates to `asyncio.to_thread` workers for delegate/Mercury logs.
- **Phased logs**: `turn_start` / `supervisor_invoke_*` / `subagent_delegate_*` / `mercury_http_*` / `mercury_invoke_*` / `turn_end` with durations where relevant.
- **LangSmith**: `@traceable(run_type="tool", name="mercury_http")` on sync Mercury `run_turn` body. Enable with standard `LANGSMITH_TRACING` + `LANGSMITH_API_KEY`.

## Tests
- `uv run pytest`: 48 passed

## Dependencies
- `rich`, `langsmith>=0.7` (direct)

Closes #4