### PR TITLE
Add long-term memory to Juno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ __pycache__/
 .coverage
 htmlcov/
 .env
+data/juno_long_term_memory/
 scripts/print_juno_graph_mermaid.py
 juno_graphs.mmd

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Relevant concepts and APIs:
 | `JUNO_ASSISTANTS_DIR` | Assistants definitions directory (optional) |
 | `JUNO_SUPERVISOR_PROMPT_PATH` | Override path to the supervisor Markdown prompt (default: `config/juno.supervisor.md` under the working directory) |
 | `JUNO_USE_STREAM` | If set truthy, sends periodic typing while the supervisor runs |
+| `JUNO_LONGTERM_MEMORY_DIR` | Per-user long-term memory JSON directory; defaults to `data/juno_long_term_memory` under the process working directory |
 
 Optional: `.env` in the project root is loaded into the process environment at bot startup (`load_dotenv`) so provider SDKs (Groq, OpenAI, etc.) see keys like `GROQ_API_KEY`; Pydantic Settings also reads the same file for app fields.
 

--- a/config/juno.supervisor.md
+++ b/config/juno.supervisor.md
@@ -8,6 +8,8 @@ When you call a specialist tool, pass a **single clear natural-language `request
 
 **Telegram approval:** If graph state already contains `approval_response` (the user finished an in-chat Approve step), you **must** invoke the **same** specialist tool again so the pending operation can resume—see that tool’s instructions for repeating intents and idempotency keys.
 
+**Long-term user memory (`update_user_memory`):** When that tool exists, call it when the user asks you to remember something or states or updates **stable** profile fields—their name, **your/agent** name, wallet address, tone, or mission. Persist **durable** preferences or facts only, not ephemeral one-off requests. **Never invent** missing wallet addresses or other profile fields; store only values the user actually gives. Their saved profile is **injected automatically** into your context on model turns—read it and honor it when you answer.
+
 ---
 
 *The next section is filled in automatically at startup from the tools actually registered for this deployment (names and descriptions).*

--- a/src/juno/agents/build_supervisor.py
+++ b/src/juno/agents/build_supervisor.py
@@ -17,6 +17,7 @@ from langchain_core.tools import BaseTool
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.graph.state import CompiledStateGraph
 
+from juno.agents.memory import build_long_term_memory_model_middleware, build_update_user_memory_tool
 from juno.agents.registry import SubagentSpec
 from juno.agents.state import CustomAgentState
 from juno.logging_config import get_trace_id
@@ -153,6 +154,7 @@ def build_supervisor(
     model: str | BaseChatModel,
     subagents: Sequence[SubagentSpec],
     additional_tools: Sequence[BaseTool] | None = None,
+    long_term_memory_dir: Path | None = None,
     supervisor_prompt_path: Path | None = None,
     system_prompt: str | None = None,
     inject_tools_context: bool = True,
@@ -172,8 +174,12 @@ def build_supervisor(
         raise ValueError("subagents must be non-empty.")
 
     tools = _subagent_tools_from_specs(tuple(subagents))
-    if additional_tools:
-        tools.extend(additional_tools)
+    extra_tools: list[BaseTool] = list(additional_tools) if additional_tools else []
+    memory_middleware: tuple[Any, ...] = ()
+    if long_term_memory_dir is not None:
+        extra_tools.append(build_update_user_memory_tool(long_term_memory_dir))
+        memory_middleware = (build_long_term_memory_model_middleware(long_term_memory_dir),)
+    tools.extend(extra_tools)
 
     if system_prompt is not None:
         base = system_prompt
@@ -191,6 +197,7 @@ def build_supervisor(
         system_prompt=prompt,
         checkpointer=InMemorySaver(),
         state_schema=CustomAgentState,
+        middleware=memory_middleware,
     )
 
 

--- a/src/juno/agents/memory.py
+++ b/src/juno/agents/memory.py
@@ -1,0 +1,116 @@
+"""Supervisor long-term memory: update tool and model-call profile injection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from langchain.agents.middleware import wrap_model_call
+from langchain.agents.middleware.types import ModelRequest
+from langchain.tools import ToolRuntime, tool
+from langchain_core.messages import SystemMessage
+from langchain_core.tools import BaseTool
+
+from juno.agents.state import CustomAgentState
+from juno.memory import UserMemoryProfile, format_user_memory_for_prompt, load_user_memory, merge_user_memory
+
+_LTM_HEADING = "## Long-term profile"
+
+
+def _system_message_text(msg: SystemMessage | None) -> str:
+    if msg is None:
+        return ""
+    content = msg.content
+    if isinstance(content, str):
+        return content
+    return str(content)
+
+
+def _profile_effective_summary(profile: UserMemoryProfile) -> str:
+    tone = (profile.tone or "").strip() or "concise"
+    parts: list[str] = [f"tone={tone!r}"]
+    if profile.user_name:
+        parts.append(f"user_name={profile.user_name!r}")
+    if profile.agent_name:
+        parts.append(f"agent_name={profile.agent_name!r}")
+    if profile.wallet_address:
+        parts.append(f"wallet_address={profile.wallet_address!r}")
+    if profile.mission:
+        mission = profile.mission.strip()
+        if len(mission) > 80:
+            mission = mission[:77] + "..."
+        parts.append(f"mission={mission!r}")
+    return ", ".join(parts)
+
+
+def build_update_user_memory_tool(memory_dir: Path) -> BaseTool:
+    """Return the ``update_user_memory`` tool bound to ``memory_dir``."""
+
+    @tool("update_user_memory")
+    def update_user_memory(
+        runtime: ToolRuntime,
+        user_name: str | None = None,
+        agent_name: str | None = None,
+        wallet_address: str | None = None,
+        tone: str | None = None,
+        mission: str | None = None,
+    ) -> str:
+        """Persist optional user preferences for this Telegram user (tone, names, wallet, mission).
+
+        Only non-null arguments overwrite stored fields. Requires ``user_id`` in agent state.
+        """
+        state = runtime.state
+        user_id = state.get("user_id") if state else None
+        if not user_id:
+            return (
+                "Error: no user_id in session state; cannot update long-term memory. "
+                "The user must be identified first."
+            )
+
+        merged = merge_user_memory(
+            memory_dir,
+            str(user_id),
+            user_name=user_name,
+            agent_name=agent_name,
+            wallet_address=wallet_address,
+            tone=tone,
+            mission=mission,
+        )
+        summary = _profile_effective_summary(merged)
+        return f"Long-term memory saved. Effective profile: {summary}."
+
+    return update_user_memory
+
+
+def build_long_term_memory_model_middleware(memory_dir: Path) -> Any:
+    """Inject a formatted long-term profile into the model request system message (per model call)."""
+
+    @wrap_model_call(state_schema=CustomAgentState, name="inject_long_term_profile")
+    def inject_long_term_profile(
+        request: ModelRequest[Any],
+        handler: Any,
+    ) -> Any:
+        state = request.state
+        user_id = state.get("user_id") if state else None
+        if not user_id:
+            return handler(request)
+
+        profile = load_user_memory(memory_dir, str(user_id))
+        block = format_user_memory_for_prompt(profile)
+        section = f"{_LTM_HEADING}\n\n{block}"
+
+        base_text = _system_message_text(request.system_message).rstrip()
+        if base_text:
+            new_content = f"{base_text}\n\n{section}"
+        else:
+            new_content = section
+
+        return handler(request.override(system_message=SystemMessage(content=new_content)))
+
+    return inject_long_term_profile
+
+
+__all__ = [
+    "build_long_term_memory_model_middleware",
+    "build_update_user_memory_tool",
+]

--- a/src/juno/agents/memory.py
+++ b/src/juno/agents/memory.py
@@ -8,13 +8,20 @@ from typing import Any
 from langchain.agents.middleware import wrap_model_call
 from langchain.agents.middleware.types import ModelRequest
 from langchain.tools import ToolRuntime, tool
-from langchain_core.messages import SystemMessage
+from langchain_core.messages import AIMessage, SystemMessage
 from langchain_core.tools import BaseTool
 
 from juno.agents.state import CustomAgentState
 from juno.memory import UserMemoryProfile, format_user_memory_for_prompt, load_user_memory, merge_user_memory
 
 _LTM_HEADING = "## Long-term profile"
+_LTM_ONBOARDING = (
+    "No long-term profile is saved for this user yet. At the start of the conversation, "
+    "ask the user for the details you should remember: their name, preferred agent name, "
+    "wallet address if any, preferred tone (default concise), and the agent mission. "
+    "Make this a brief setup question before handling other work; do not invent any values. "
+    "When the user answers, call `update_user_memory` with the provided fields."
+)
 
 
 def _system_message_text(msg: SystemMessage | None) -> str:
@@ -41,6 +48,11 @@ def _profile_effective_summary(profile: UserMemoryProfile) -> str:
             mission = mission[:77] + "..."
         parts.append(f"mission={mission!r}")
     return ", ".join(parts)
+
+
+def _is_start_of_thread(state: dict[str, Any]) -> bool:
+    messages = state.get("messages") or []
+    return not any(isinstance(message, AIMessage) for message in messages)
 
 
 def build_update_user_memory_tool(memory_dir: Path) -> BaseTool:
@@ -98,6 +110,8 @@ def build_long_term_memory_model_middleware(memory_dir: Path) -> Any:
         profile = load_user_memory(memory_dir, str(user_id))
         block = format_user_memory_for_prompt(profile)
         section = f"{_LTM_HEADING}\n\n{block}"
+        if not profile.has_saved_context() and _is_start_of_thread(state):
+            section = f"{section}\n\n{_LTM_ONBOARDING}"
 
         base_text = _system_message_text(request.system_message).rstrip()
         if base_text:

--- a/src/juno/memory/__init__.py
+++ b/src/juno/memory/__init__.py
@@ -1,0 +1,17 @@
+"""File-backed long-term memory profiles (one JSON file per user)."""
+
+from juno.memory.profile import UserMemoryProfile
+from juno.memory.store import (
+    format_user_memory_for_prompt,
+    load_user_memory,
+    merge_user_memory,
+    save_user_memory,
+)
+
+__all__ = [
+    "UserMemoryProfile",
+    "format_user_memory_for_prompt",
+    "load_user_memory",
+    "merge_user_memory",
+    "save_user_memory",
+]

--- a/src/juno/memory/profile.py
+++ b/src/juno/memory/profile.py
@@ -15,3 +15,10 @@ class UserMemoryProfile(BaseModel):
     wallet_address: str | None = Field(default=None, description="Optional on-chain address.")
     mission: str | None = Field(default=None, description="Standing goals or mission text.")
     tone: str = Field(default="concise", description="Style hint for replies (default concise).")
+
+    def has_saved_context(self) -> bool:
+        """Return true when the profile contains user-provided long-term context."""
+        fields = (self.user_name, self.agent_name, self.wallet_address, self.mission)
+        if any(value is not None and str(value).strip() for value in fields):
+            return True
+        return bool((self.tone or "").strip() and self.tone.strip() != "concise")

--- a/src/juno/memory/profile.py
+++ b/src/juno/memory/profile.py
@@ -1,0 +1,17 @@
+"""Pydantic model for persisted user-scoped long-term memory."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class UserMemoryProfile(BaseModel):
+    """Fixed-field profile stored as one JSON file per Telegram user."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    user_name: str | None = Field(default=None, description="How to address the user.")
+    agent_name: str | None = Field(default=None, description="Preferred agent / assistant name.")
+    wallet_address: str | None = Field(default=None, description="Optional on-chain address.")
+    mission: str | None = Field(default=None, description="Standing goals or mission text.")
+    tone: str = Field(default="concise", description="Style hint for replies (default concise).")

--- a/src/juno/memory/store.py
+++ b/src/juno/memory/store.py
@@ -1,0 +1,123 @@
+"""Load, save, merge, and format file-backed user memory profiles."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from juno.memory.profile import UserMemoryProfile
+
+_MEMORY_FILENAME_SUFFIX = ".json"
+_MAX_PROMPT_CHARS = 2048
+
+
+def _memory_stem_for_user_id(user_id: str) -> str:
+    """Deterministic, filesystem-safe stem derived from ``user_id``."""
+    digest = hashlib.sha256(user_id.encode("utf-8")).hexdigest()
+    return digest
+
+
+def memory_file_path(memory_dir: Path, user_id: str) -> Path:
+    """Resolved JSON path for ``user_id`` under ``memory_dir``."""
+    stem = _memory_stem_for_user_id(user_id)
+    return memory_dir / f"{stem}{_MEMORY_FILENAME_SUFFIX}"
+
+
+def load_user_memory(memory_dir: Path, user_id: str) -> UserMemoryProfile:
+    """Load profile from disk; if the file is missing, return defaults."""
+    path = memory_file_path(memory_dir, user_id)
+    if not path.is_file():
+        return UserMemoryProfile()
+    raw = path.read_text(encoding="utf-8")
+    data = json.loads(raw)
+    return UserMemoryProfile.model_validate(data)
+
+
+def save_user_memory(memory_dir: Path, user_id: str, profile: UserMemoryProfile) -> None:
+    """Persist ``profile`` with atomic replace (temp file in same directory)."""
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    path = memory_file_path(memory_dir, user_id)
+    payload = profile.model_dump_json(indent=2, exclude_none=True).encode("utf-8")
+    fd, tmp = tempfile.mkstemp(
+        dir=memory_dir,
+        prefix=".tmp_memory_",
+        suffix=_MEMORY_FILENAME_SUFFIX,
+    )
+    try:
+        with os.fdopen(fd, "wb") as fp:
+            fp.write(payload)
+            fp.flush()
+            os.fsync(fp.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def merge_user_memory(
+    memory_dir: Path,
+    user_id: str,
+    updates: Mapping[str, Any] | None = None,
+    **kwargs: Any,
+) -> UserMemoryProfile:
+    """Apply partial updates; only non-``None`` values overwrite. Result is persisted."""
+    patch: dict[str, Any] = {}
+    if updates:
+        patch.update(dict(updates))
+    patch.update(kwargs)
+
+    current = load_user_memory(memory_dir, user_id)
+    allowed = UserMemoryProfile.model_fields
+    applied: dict[str, Any] = {}
+    for key, value in patch.items():
+        if key not in allowed:
+            msg = f"Unknown UserMemoryProfile field: {key!r}"
+            raise ValueError(msg)
+        if value is None:
+            continue
+        applied[key] = value
+
+    merged = UserMemoryProfile.model_validate({**current.model_dump(), **applied})
+    save_user_memory(memory_dir, user_id, merged)
+    return merged
+
+
+def format_user_memory_for_prompt(
+    profile: UserMemoryProfile,
+    *,
+    max_chars: int = _MAX_PROMPT_CHARS,
+) -> str:
+    """Plain markdown block: always includes effective tone; skips empty fields."""
+    raw_tone = (profile.tone or "").strip()
+    tone = raw_tone or "concise"
+    lines: list[str] = [
+        "### User memory",
+        "",
+        f"- **Tone:** {tone}",
+    ]
+    fields: tuple[tuple[str, str | None], ...] = (
+        ("User name", profile.user_name),
+        ("Agent name", profile.agent_name),
+        ("Wallet address", profile.wallet_address),
+        ("Mission", profile.mission),
+    )
+    for label, value in fields:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if not text:
+            continue
+        lines.append(f"- **{label}:** {text}")
+
+    out = "\n".join(lines)
+    if len(out) <= max_chars:
+        return out
+    return f"{out[: max_chars - 3].rstrip()}..."

--- a/src/juno/memory/store.py
+++ b/src/juno/memory/store.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from pydantic import ValidationError
+
 from juno.memory.profile import UserMemoryProfile
+
+logger = logging.getLogger(__name__)
 
 _MEMORY_FILENAME_SUFFIX = ".json"
 _MAX_PROMPT_CHARS = 2048
@@ -33,9 +38,13 @@ def load_user_memory(memory_dir: Path, user_id: str) -> UserMemoryProfile:
     path = memory_file_path(memory_dir, user_id)
     if not path.is_file():
         return UserMemoryProfile()
-    raw = path.read_text(encoding="utf-8")
-    data = json.loads(raw)
-    return UserMemoryProfile.model_validate(data)
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        return UserMemoryProfile.model_validate(data)
+    except (OSError, json.JSONDecodeError, ValidationError):
+        logger.warning("Ignoring unreadable long-term memory profile at %s", path, exc_info=True)
+        return UserMemoryProfile()
 
 
 def save_user_memory(memory_dir: Path, user_id: str, profile: UserMemoryProfile) -> None:

--- a/src/juno/runtime/factory.py
+++ b/src/juno/runtime/factory.py
@@ -75,6 +75,7 @@ def build_supervisor_bundle(settings: Settings) -> SupervisorBundle:
         model=settings.openai_model,
         subagents=specs,
         supervisor_prompt_path=settings.juno_supervisor_prompt_path,
+        long_term_memory_dir=settings.juno_long_term_memory_dir,
     )
     return SupervisorBundle(
         graph=graph,

--- a/src/juno/settings.py
+++ b/src/juno/settings.py
@@ -61,3 +61,11 @@ class Settings(BaseSettings):
         default=False,
         description="If true, send periodic typing while the supervisor runs; env ``JUNO_USE_STREAM``.",
     )
+    juno_long_term_memory_dir: Path = Field(
+        default=Path("data") / "juno_long_term_memory",
+        validation_alias=AliasChoices("JUNO_LONGTERM_MEMORY_DIR"),
+        description=(
+            "Directory for per-user long-term memory JSON files; env ``JUNO_LONGTERM_MEMORY_DIR``. "
+            "Default ``data/juno_long_term_memory`` relative to the process working directory."
+        ),
+    )

--- a/tests/test_long_term_memory.py
+++ b/tests/test_long_term_memory.py
@@ -41,6 +41,7 @@ def test_load_user_memory_missing_file_default_tone_concise(tmp_path: Path) -> N
     profile = load_user_memory(tmp_path, "any-user-id")
     assert profile.tone == "concise"
     assert profile.user_name is None
+    assert not profile.has_saved_context()
 
 
 def test_load_user_memory_empty_json_object_default_tone_concise(tmp_path: Path) -> None:
@@ -173,6 +174,13 @@ def test_format_user_memory_for_prompt_fallback_tone_when_blank() -> None:
     assert "**Tone:** concise" in text
 
 
+def test_user_memory_profile_saved_context_detection() -> None:
+    assert not UserMemoryProfile().has_saved_context()
+    assert not UserMemoryProfile(tone="concise").has_saved_context()
+    assert UserMemoryProfile(user_name="Pat").has_saved_context()
+    assert UserMemoryProfile(tone="formal").has_saved_context()
+
+
 def test_supervisor_update_user_memory_persists_profile_json(tmp_path: Path) -> None:
     def boom(request: httpx.Request) -> httpx.Response:
         raise AssertionError("Mercury should not be called")
@@ -284,6 +292,8 @@ def test_long_term_memory_middleware_injects_profile_with_default_and_saved_fiel
     sys_a = _first_system_content(invocations[-1])
     assert "## Long-term profile" in sys_a
     assert "**Tone:** concise" in sys_a
+    assert "No long-term profile is saved for this user yet." in sys_a
+    assert "update_user_memory" in sys_a
 
     merge_user_memory(
         tmp_path,
@@ -302,3 +312,4 @@ def test_long_term_memory_middleware_injects_profile_with_default_and_saved_fiel
     assert "**Tone:** playful" in sys_b
     assert "**User name:** Ravi" in sys_b
     assert "**Mission:** Test middleware injection." in sys_b
+    assert "No long-term profile is saved for this user yet." not in sys_b

--- a/tests/test_long_term_memory.py
+++ b/tests/test_long_term_memory.py
@@ -1,0 +1,292 @@
+"""Tests for file-backed long-term memory (profile, store, supervisor tool, middleware)."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from pathlib import Path
+
+import httpx
+import pytest
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from juno.agents import build_mercury_subagent, build_supervisor, default_mercury_subagent_spec
+from juno.assistants.loader import AssistantManifest
+from juno.assistants.mercury_runner import MercuryAssistantRunner
+from juno.memory import UserMemoryProfile, format_user_memory_for_prompt, load_user_memory, merge_user_memory, save_user_memory
+from juno.memory.store import memory_file_path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SUPERVISOR_PROMPT_PATH = _REPO_ROOT / "config" / "juno.supervisor.md"
+
+
+class FakeMessagesListChatModelWithTools(FakeMessagesListChatModel):
+    """:class:`FakeMessagesListChatModel` does not implement ``bind_tools``; agents require it."""
+
+    def bind_tools(self, tools, *, tool_choice=None, **kwargs):  # type: ignore[no-untyped-def]
+        return self
+
+
+def _thread_config() -> dict:
+    return {"configurable": {"thread_id": f"test-{uuid.uuid4()}"}}
+
+
+def _hex_stem_json_files(directory: Path) -> list[Path]:
+    return [p for p in directory.glob("*.json") if re.fullmatch(r"[0-9a-f]{64}\.json", p.name)]
+
+
+def test_load_user_memory_missing_file_default_tone_concise(tmp_path: Path) -> None:
+    profile = load_user_memory(tmp_path, "any-user-id")
+    assert profile.tone == "concise"
+    assert profile.user_name is None
+
+
+def test_load_user_memory_empty_json_object_default_tone_concise(tmp_path: Path) -> None:
+    uid = "u-empty-json"
+    path = memory_file_path(tmp_path, uid)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}", encoding="utf-8")
+    profile = load_user_memory(tmp_path, uid)
+    assert profile.tone == "concise"
+
+
+def test_save_merge_round_trip_persist_fields_and_safe_filename(tmp_path: Path) -> None:
+    uid = "telegram|12345"
+    original = UserMemoryProfile(
+        user_name="Ada",
+        agent_name="Nova",
+        wallet_address="0xdeadbeef",
+        mission="Study agents.",
+        tone="friendly",
+    )
+    save_user_memory(tmp_path, uid, original)
+
+    hashed = _hex_stem_json_files(tmp_path)
+    assert len(hashed) == 1
+    stem = hashed[0].stem
+    assert len(stem) == 64
+    assert re.fullmatch(r"[0-9a-f]{64}", stem)
+
+    merged = merge_user_memory(
+        tmp_path,
+        uid,
+        mission="Updated mission text.",
+        user_name=None,
+    )
+    assert merged.user_name == "Ada"
+    assert merged.agent_name == "Nova"
+    assert merged.wallet_address == "0xdeadbeef"
+    assert merged.tone == "friendly"
+    assert merged.mission == "Updated mission text."
+
+    loaded = load_user_memory(tmp_path, uid)
+    assert loaded == merged
+
+    assert memory_file_path(tmp_path, uid) == hashed[0]
+
+
+def test_merge_ignores_none_and_rejects_unknown_fields(tmp_path: Path) -> None:
+    uid = "merge-user"
+    save_user_memory(
+        tmp_path,
+        uid,
+        UserMemoryProfile(user_name="First", tone="friendly", mission="stay"),
+    )
+    merged = merge_user_memory(
+        tmp_path,
+        uid,
+        agent_name=None,
+        user_name="Second",
+        mission=None,
+        tone=None,
+        wallet_address=None,
+    )
+    assert merged.user_name == "Second"
+    assert merged.mission == "stay"
+    assert merged.agent_name is None
+    assert merged.tone == "friendly"
+
+    with pytest.raises(ValueError, match="Unknown UserMemoryProfile field"):
+        merge_user_memory(tmp_path, uid, not_a_real_field="nope")
+
+
+@pytest.mark.parametrize(
+    ("profile", "must_contain", "must_not_contain"),
+    [
+        (
+            UserMemoryProfile(),
+            ("### User memory", "**Tone:** concise"),
+            ("**User name:**", "**Agent name:**", "**Mission:**"),
+        ),
+        (
+            UserMemoryProfile(user_name="", mission="   ", tone="witty"),
+            ("### User memory", "**Tone:** witty"),
+            ("**User name:**", "**Mission:**"),
+        ),
+        (
+            UserMemoryProfile(
+                user_name="Pat",
+                agent_name="Juno",
+                wallet_address="0xw",
+                mission="Ship",
+                tone="professional",
+            ),
+            (
+                "**Tone:** professional",
+                "**User name:** Pat",
+                "**Agent name:** Juno",
+                "**Wallet address:** 0xw",
+                "**Mission:** Ship",
+            ),
+            (),
+        ),
+    ],
+)
+def test_format_user_memory_for_prompt_tone_and_nonempty_fields_only(
+    profile: UserMemoryProfile,
+    must_contain: tuple[str, ...],
+    must_not_contain: tuple[str, ...],
+) -> None:
+    text = format_user_memory_for_prompt(profile)
+    for needle in must_contain:
+        assert needle in text, text
+    for needle in must_not_contain:
+        assert needle not in text, text
+
+
+def test_format_user_memory_for_prompt_fallback_tone_when_blank() -> None:
+    text = format_user_memory_for_prompt(UserMemoryProfile.model_validate({"tone": "  "}))
+    assert "**Tone:** concise" in text
+
+
+def test_supervisor_update_user_memory_persists_profile_json(tmp_path: Path) -> None:
+    def boom(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("Mercury should not be called")
+
+    runner = MercuryAssistantRunner(
+        "https://unused.test",
+        transport=httpx.MockTransport(boom),
+        http_path="/v1/agent",
+        request_body_mode="flat",
+    )
+    manifest = AssistantManifest(runner="mercury", base_url_env="X", system_prompt="Sub")
+    sub = build_mercury_subagent(
+        model=FakeMessagesListChatModelWithTools(responses=[AIMessage(content="noop")]),
+        manifest=manifest,
+        runner=runner,
+    )
+
+    uid = "ltm-tool-user-1"
+    responses = [
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "update_user_memory",
+                    "args": {"user_name": "Casey", "tone": "technical"},
+                    "id": "mem-1",
+                    "type": "tool_call",
+                }
+            ],
+        ),
+        AIMessage(content="stored."),
+    ]
+    model = FakeMessagesListChatModelWithTools(responses=responses)
+    sup = build_supervisor(
+        model=model,
+        subagents=(default_mercury_subagent_spec(sub),),
+        supervisor_prompt_path=_SUPERVISOR_PROMPT_PATH,
+        long_term_memory_dir=tmp_path,
+    )
+
+    out = sup.invoke(
+        {"messages": [HumanMessage("save prefs")], "user_id": uid},
+        _thread_config(),
+    )
+    assert out["messages"][-1].content == "stored."
+
+    files = _hex_stem_json_files(tmp_path)
+    assert len(files) == 1
+    disk = json.loads(files[0].read_text(encoding="utf-8"))
+    assert disk.get("user_name") == "Casey"
+    assert disk.get("tone") == "technical"
+    assert load_user_memory(tmp_path, uid).user_name == "Casey"
+
+
+def _capturing_fake_with_tools(
+    responses: list[AIMessage],
+    captures: list[list],
+) -> FakeMessagesListChatModelWithTools:
+    """Subclass inside factory so pydantic ignores custom capture state."""
+
+    class _Capturing(FakeMessagesListChatModelWithTools):
+        def _generate(self, messages: list, stop=None, run_manager=None, **kwargs):  # type: ignore[no-untyped-def]
+            captures.append(list(messages))
+            return super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+    return _Capturing(responses=responses)
+
+
+def _first_system_content(messages: list) -> str:
+    for msg in messages:
+        if isinstance(msg, SystemMessage):
+            c = msg.content
+            return c if isinstance(c, str) else str(c)
+    return ""
+
+
+def test_long_term_memory_middleware_injects_profile_with_default_and_saved_fields(tmp_path: Path) -> None:
+    def boom(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("Mercury should not be called")
+
+    runner = MercuryAssistantRunner(
+        "https://unused.test",
+        transport=httpx.MockTransport(boom),
+        http_path="/v1/agent",
+        request_body_mode="flat",
+    )
+    manifest = AssistantManifest(runner="mercury", base_url_env="X", system_prompt="Sub")
+    sub = build_mercury_subagent(
+        model=FakeMessagesListChatModelWithTools(responses=[AIMessage(content="noop")]),
+        manifest=manifest,
+        runner=runner,
+    )
+
+    uid = uuid.uuid4().hex
+    invocations: list[list] = []
+    capturing_model = _capturing_fake_with_tools(
+        responses=[AIMessage(content="phase-a"), AIMessage(content="phase-b")],
+        captures=invocations,
+    )
+    sup = build_supervisor(
+        model=capturing_model,
+        subagents=(default_mercury_subagent_spec(sub),),
+        supervisor_prompt_path=_SUPERVISOR_PROMPT_PATH,
+        long_term_memory_dir=tmp_path,
+    )
+    cfg = _thread_config()
+
+    sup.invoke({"messages": [HumanMessage("one")], "user_id": uid}, cfg)
+    sys_a = _first_system_content(invocations[-1])
+    assert "## Long-term profile" in sys_a
+    assert "**Tone:** concise" in sys_a
+
+    merge_user_memory(
+        tmp_path,
+        uid,
+        user_name="Ravi",
+        mission="Test middleware injection.",
+        tone="playful",
+    )
+
+    capturing_model.i = 0
+    invocations.clear()
+    sup.invoke({"messages": [HumanMessage("two")], "user_id": uid}, cfg)
+
+    sys_b = _first_system_content(invocations[-1])
+    assert "## Long-term profile" in sys_b
+    assert "**Tone:** playful" in sys_b
+    assert "**User name:** Ravi" in sys_b
+    assert "**Mission:** Test middleware injection." in sys_b

--- a/tests/test_long_term_memory.py
+++ b/tests/test_long_term_memory.py
@@ -52,6 +52,18 @@ def test_load_user_memory_empty_json_object_default_tone_concise(tmp_path: Path)
     assert profile.tone == "concise"
 
 
+def test_load_user_memory_invalid_json_falls_back_to_default(tmp_path: Path) -> None:
+    uid = "u-invalid-json"
+    path = memory_file_path(tmp_path, uid)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"tone": null', encoding="utf-8")
+
+    profile = load_user_memory(tmp_path, uid)
+
+    assert profile.tone == "concise"
+    assert profile.user_name is None
+
+
 def test_save_merge_round_trip_persist_fields_and_safe_filename(tmp_path: Path) -> None:
     uid = "telegram|12345"
     original = UserMemoryProfile(


### PR DESCRIPTION
## Summary
- Add file-backed per-user long-term memory profiles for user name, agent name, wallet address, tone, and mission.
- Wire an `update_user_memory` supervisor tool plus middleware that injects the saved profile into model calls.
- Document the memory behavior/configuration and add focused tests for persistence, tool execution, middleware injection, and invalid profile fallback.

## Test plan
- `uv run pytest tests/test_runtime_factory.py tests/test_agents.py -q`
- `uv run pytest tests/test_loaders.py tests/test_runtime_factory.py -q`
- `uv run pytest tests/test_long_term_memory.py -q`
- `uv run pytest -q`
- `git diff --check main...HEAD`

Closes #2.