### PR TITLE
Add Shroud LLM routing for Juno

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,85 @@
+# Juno `.env.example`
+#
+# Usage:
+#   cp .env.example .env
+#   edit `.env`
+#
+# Notes:
+# - `src/juno/telegram/bot.py` calls `python-dotenv` `load_dotenv()` so provider SDKs (OpenAI/Groq)
+#   can read API keys from the environment.
+# - `pydantic-settings` also reads `.env` for Juno `Settings` fields.
+# - Do not commit a real `.env` file.
+
+# --- Telegram / identity ---
+TELEGRAM_BOT_TOKEN=
+# Optional: override default `config/juno.identity.yaml` path
+# JUNO_IDENTITY_PATH=config/juno.identity.yaml
+
+# --- LangChain model selection ---
+# Use a colon (`provider:model`), not a slash.
+JUNO_MODEL=openai:gpt-4o-mini
+# OPENAI_MODEL=openai:gpt-4o-mini
+
+# --- Provider API keys (non-Shroud path) ---
+# These are required when `JUNO_USE_SHROUD` is false and your model id needs them
+# (e.g. `openai:...` needs `OPENAI_API_KEY`, `groq:...` needs `GROQ_API_KEY`).
+OPENAI_API_KEY=
+# GROQ_API_KEY=
+
+# --- Mercury (HTTP to the Mercury service; always direct, not via Shroud) ---
+MERCURY_BASE_URL=
+# MERCURY_HTTP_PATH=/v1/mercury/invoke
+# MERCURY_REQUEST_BODY_MODE=flat
+
+# --- Optional Juno paths / UX ---
+# JUNO_ASSISTANTS_DIR=assistants
+# JUNO_SUPERVISOR_PROMPT_PATH=config/juno.supervisor.md
+# JUNO_USE_STREAM=false
+# JUNO_LONGTERM_MEMORY_DIR=data/juno_long_term_memory
+
+# --- Logging ---
+# JUNO_LOG_LEVEL=INFO
+# JUNO_LOG_COLOR=true
+# NO_COLOR=
+
+# --- Shroud (optional; OpenAI-compatible chat completions path) ---
+# When enabled, Juno builds a `ChatOpenAI` client pointed at `JUNO_LLM_BASE_URL` and sends:
+# - `X-Shroud-Agent-Key` from `$JUNO_SHROUD_AGENT_KEY`
+# - `X-Shroud-Provider` from `JUNO_SHROUD_PROVIDER`
+# - optionally `X-Shroud-Model` derived from `JUNO_MODEL` (enabled by default)
+#
+# Vault-resolved upstream provider keys happen on the Shroud side; you typically do NOT set
+# `OPENAI_API_KEY` / `GROQ_API_KEY` in Juno for that deployment mode.
+#
+# Rollback: `JUNO_USE_SHROUD=false` (or unset) and restore normal provider keys as needed.
+#
+# Bool parsing: pydantic-settings treats many truthy strings as true (`true`, `1`, etc.).
+JUNO_USE_SHROUD=false
+# Alternate flags (aliases):
+# JUNO_SHROUD_ENABLED=false
+# SHROUD_ENABLED=false
+
+# OpenAI-compatible base URL (includes `/v1` for direct Shroud)
+JUNO_LLM_BASE_URL=https://shroud.1claw.xyz/v1
+# Alternate names (aliases):
+# JUNO_SHROUD_BASE_URL=https://shroud.1claw.xyz/v1
+# SHROUD_OPENAI_BASE_URL=https://shroud.1claw.xyz/v1
+
+# Upstream provider Shroud routes to for OpenAI-compatible chat completions (`openai`, `google`, `openrouter`, ...).
+JUNO_SHROUD_PROVIDER=openai
+# SHROUD_PROVIDER=openai
+
+# Process env var NAME that holds the Shroud credential string `agent_uuid:ocv_...`
+# Defaults to `JUNO_SHROUD_AGENT_KEY`:
+# JUNO_SHROUD_AGENT_KEY_ENV=JUNO_SHROUD_AGENT_KEY
+
+# Actual Shroud credential (do not commit real values)
+JUNO_SHROUD_AGENT_KEY=
+
+# Send `X-Shroud-Model` header (recommended)
+JUNO_SHROUD_MODEL_HEADER=true
+
+# --- Optional tooling / telemetry (picked up directly from `os.environ` by libs) ---
+# LANGSMITH_TRACING=true
+# LANGSMITH_API_KEY=
+# LANGSMITH_PROJECT=juno-local

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Relevant concepts and APIs:
 
 Optional: `.env` in the project root is loaded into the process environment at bot startup (`load_dotenv`) so provider SDKs (Groq, OpenAI, etc.) see keys like `GROQ_API_KEY`; Pydantic Settings also reads the same file for app fields.
 
+Start from the template:
+
+```bash
+cp .env.example .env
+```
+
 ### Shroud (vault-resolved LLM)
 
 When Shroud is enabled, **only** LangChain LLM traffic uses `JUNO_LLM_BASE_URL` (or its aliases). Calls to **Mercury** still use `MERCURY_BASE_URL` directly.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Relevant concepts and APIs:
 | `OPENAI_API_KEY` | API key when using OpenAI-backed models; identity YAML `secrets.openai_api_key_env` names this (default `OPENAI_API_KEY`) |
 | `GROQ_API_KEY` | Required when `JUNO_MODEL` / `OPENAI_MODEL` uses the `groq:` provider (e.g. `groq:llama-3.3-70b-versatile`) |
 | `JUNO_MODEL` or `OPENAI_MODEL` | LangChain chat model id (e.g. `openai:gpt-4o-mini`, `groq:...`) — use a **colon** (`provider:model`), not a slash |
+| `JUNO_USE_SHROUD` | If truthy, route **supervisor/sub-agent LLM** calls through Shroud (OpenAI-compatible HTTP). Aliases: `JUNO_SHROUD_ENABLED`, `SHROUD_ENABLED`. Default off |
+| `JUNO_LLM_BASE_URL` | Shroud OpenAI-compatible base URL when Shroud is on (default in settings: `https://shroud.1claw.xyz/v1`). Aliases: `JUNO_SHROUD_BASE_URL`, `SHROUD_OPENAI_BASE_URL` |
+| `JUNO_SHROUD_PROVIDER` | Upstream provider Shroud should use for OpenAI-compatible chat completions (e.g. `openai`, `google`, `openrouter`). Alias: `SHROUD_PROVIDER` |
+| `JUNO_SHROUD_AGENT_KEY_ENV` | **Name** of the env var that holds the Shroud agent credential (`agent_id:ocv_...`); settings never embed the secret. Default name: `JUNO_SHROUD_AGENT_KEY`. Alias: `SHROUD_AGENT_KEY_ENV` |
+| `JUNO_SHROUD_MODEL_HEADER` | If truthy, send the active model id to Shroud (default on). Alias: `SHROUD_MODEL_HEADER` |
 | `JUNO_IDENTITY_PATH` | Path to identity YAML (optional; defaults apply if unset) |
 | `JUNO_ASSISTANTS_DIR` | Assistants definitions directory (optional) |
 | `JUNO_SUPERVISOR_PROMPT_PATH` | Override path to the supervisor Markdown prompt (default: `config/juno.supervisor.md` under the working directory) |
@@ -71,6 +76,25 @@ Relevant concepts and APIs:
 | `JUNO_LONGTERM_MEMORY_DIR` | Per-user long-term memory JSON directory; defaults to `data/juno_long_term_memory` under the process working directory |
 
 Optional: `.env` in the project root is loaded into the process environment at bot startup (`load_dotenv`) so provider SDKs (Groq, OpenAI, etc.) see keys like `GROQ_API_KEY`; Pydantic Settings also reads the same file for app fields.
+
+### Shroud (vault-resolved LLM)
+
+When Shroud is enabled, **only** LangChain LLM traffic uses `JUNO_LLM_BASE_URL` (or its aliases). Calls to **Mercury** still use `MERCURY_BASE_URL` directly.
+
+With **vault-resolved** upstream credentials, Shroud loads the provider API key from **1Claw Vault** (for example `providers/{provider}/api-key`) using the agent’s vault permissions. You do **not** set `OPENAI_API_KEY`, `GROQ_API_KEY`, or similar in Juno for that path. Juno must still supply the Shroud **agent** credential via the env var named by `JUNO_SHROUD_AGENT_KEY_ENV` (by default set `JUNO_SHROUD_AGENT_KEY`).
+
+Minimal example (direct Shroud, vault-backed provider key):
+
+```bash
+export MERCURY_BASE_URL="https://your-mercury.example"
+export JUNO_USE_SHROUD=true
+export JUNO_LLM_BASE_URL="https://shroud.1claw.xyz/v1"
+export JUNO_SHROUD_PROVIDER="openai"
+export JUNO_SHROUD_AGENT_KEY="agent_id:ocv_..."   # agent key for Shroud; upstream key comes from Vault
+export JUNO_MODEL="openai:gpt-4o-mini"
+```
+
+**Rollout:** validate in **staging** first. For production, prefer a **warn-first** or gradual cutover (monitor errors/latency), then widen. **Rollback:** set `JUNO_USE_SHROUD=false` or unset it and restart; supply normal provider keys again if you are not using Shroud.
 
 ## Run
 

--- a/src/juno/llm/__init__.py
+++ b/src/juno/llm/__init__.py
@@ -1,0 +1,5 @@
+"""LangChain chat model construction helpers."""
+
+from juno.llm.factory import build_agent_chat_model
+
+__all__ = ["build_agent_chat_model"]

--- a/src/juno/llm/factory.py
+++ b/src/juno/llm/factory.py
@@ -1,0 +1,70 @@
+"""Central factory for supervisor/sub-agent chat models (standard vs Shroud)."""
+
+from __future__ import annotations
+
+import os
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_openai import ChatOpenAI
+
+from juno.settings import Settings
+
+
+def _openai_compatible_model_id(openai_model: str) -> str:
+    """Map LangChain-style ids such as ``openai:gpt-4o-mini`` to an OpenAI-compatible ``model`` name."""
+    s = openai_model.strip()
+    if ":" in s:
+        return s.split(":", 1)[1].strip()
+    return s
+
+
+def build_agent_chat_model(settings: Settings) -> str | BaseChatModel:
+    """Return a LangChain ``create_agent`` model argument.
+
+    In normal mode, returns ``settings.openai_model`` unchanged (framework-supported model string).
+
+    When ``settings.juno_use_shroud`` is true, returns :class:`~langchain_openai.ChatOpenAI` targeting
+    ``settings.juno_llm_base_url`` with Shroud vault headers (no upstream provider API key).
+
+    Raises:
+        ValueError: Shroud enabled but required configuration or agent key env is missing.
+    """
+    if not settings.juno_use_shroud:
+        return settings.openai_model
+
+    env_name = settings.juno_shroud_agent_key_env.strip()
+    if not env_name:
+        msg = (
+            "Shroud is enabled but juno_shroud_agent_key_env is empty; configure which "
+            "environment variable supplies X-Shroud-Agent-Key."
+        )
+        raise ValueError(msg)
+
+    agent_key = os.environ.get(env_name, "").strip()
+    if not agent_key:
+        raise ValueError(
+            f"Shroud is enabled but environment variable {env_name!r} is unset or empty.",
+        )
+
+    base_url = settings.juno_llm_base_url.strip()
+    if not base_url:
+        msg = (
+            "Shroud is enabled but juno_llm_base_url is empty; set an OpenAI-compatible base URL."
+        )
+        raise ValueError(msg)
+
+    model_id = _openai_compatible_model_id(settings.openai_model)
+    headers: dict[str, str] = {
+        "X-Shroud-Agent-Key": agent_key,
+        "X-Shroud-Provider": settings.juno_shroud_provider.strip(),
+    }
+    if settings.juno_shroud_model_header:
+        headers["X-Shroud-Model"] = model_id
+
+    # Upstream provider keys are not used; Shroud validates vault credentials via headers.
+    return ChatOpenAI(
+        model=model_id,
+        base_url=base_url,
+        api_key="unused",
+        default_headers=headers,
+    )

--- a/src/juno/runtime/factory.py
+++ b/src/juno/runtime/factory.py
@@ -7,12 +7,14 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from langchain_core.language_models.chat_models import BaseChatModel
 from langgraph.graph.state import CompiledStateGraph
 
 from juno.agents import build_mercury_subagent, build_supervisor, default_mercury_subagent_spec
 from juno.agents.registry import SubagentSpec
 from juno.assistants.loader import AssistantManifest, discover_assistants
 from juno.assistants.mercury_runner import MercuryAssistantRunner
+from juno.llm.factory import build_agent_chat_model
 from juno.settings import Settings
 
 
@@ -39,8 +41,14 @@ def resolve_assistant_base_url(manifest: AssistantManifest, settings: Settings) 
     )
 
 
-def build_subagent_specs(settings: Settings) -> list[SubagentSpec]:
+def build_subagent_specs(
+    settings: Settings,
+    agent_model: str | BaseChatModel | None = None,
+) -> list[SubagentSpec]:
     """Dispatch on ``AssistantManifest.runner`` and return one :class:`SubagentSpec` per assistant."""
+    if agent_model is None:
+        agent_model = build_agent_chat_model(settings)
+
     assistants_root = (
         settings.juno_assistants_dir if settings.juno_assistants_dir is not None else Path("assistants")
     )
@@ -61,7 +69,7 @@ def build_subagent_specs(settings: Settings) -> list[SubagentSpec]:
         request_body_mode=settings.mercury_request_body_mode,
     )
     sub = build_mercury_subagent(
-        model=settings.openai_model,
+        model=agent_model,
         manifest=mercury_manifest,
         runner=runner,
     )
@@ -70,9 +78,10 @@ def build_subagent_specs(settings: Settings) -> list[SubagentSpec]:
 
 def build_supervisor_bundle(settings: Settings) -> SupervisorBundle:
     """Load manifests, build sub-agents and supervisor once; includes approval-ui metadata."""
-    specs = build_subagent_specs(settings)
+    agent_model = build_agent_chat_model(settings)
+    specs = build_subagent_specs(settings, agent_model)
     graph = build_supervisor(
-        model=settings.openai_model,
+        model=agent_model,
         subagents=specs,
         supervisor_prompt_path=settings.juno_supervisor_prompt_path,
         long_term_memory_dir=settings.juno_long_term_memory_dir,

--- a/src/juno/settings.py
+++ b/src/juno/settings.py
@@ -97,8 +97,9 @@ class Settings(BaseSettings):
         default="openai",
         validation_alias=AliasChoices("JUNO_SHROUD_PROVIDER", "SHROUD_PROVIDER"),
         description=(
-            "Shroud upstream provider header value, such as ``openai``, ``anthropic``, "
-            "or ``google``; env ``JUNO_SHROUD_PROVIDER`` or ``SHROUD_PROVIDER``."
+            "Shroud upstream provider header value for OpenAI-compatible chat completions, "
+            "such as ``openai``, ``google``, or ``openrouter``; env ``JUNO_SHROUD_PROVIDER`` "
+            "or ``SHROUD_PROVIDER``."
         ),
     )
     juno_shroud_agent_key_env: str = Field(

--- a/src/juno/settings.py
+++ b/src/juno/settings.py
@@ -69,3 +69,52 @@ class Settings(BaseSettings):
             "Default ``data/juno_long_term_memory`` relative to the process working directory."
         ),
     )
+    juno_use_shroud: bool = Field(
+        default=False,
+        validation_alias=AliasChoices(
+            "JUNO_USE_SHROUD",
+            "JUNO_SHROUD_ENABLED",
+            "SHROUD_ENABLED",
+        ),
+        description=(
+            "If true, route LLM calls through Shroud using an OpenAI-compatible HTTP API; "
+            "env ``JUNO_USE_SHROUD``, ``JUNO_SHROUD_ENABLED``, or ``SHROUD_ENABLED``."
+        ),
+    )
+    juno_llm_base_url: str = Field(
+        default="https://shroud.1claw.xyz/v1",
+        validation_alias=AliasChoices(
+            "JUNO_LLM_BASE_URL",
+            "JUNO_SHROUD_BASE_URL",
+            "SHROUD_OPENAI_BASE_URL",
+        ),
+        description=(
+            "OpenAI-compatible API base URL used when Shroud is enabled; env "
+            "``JUNO_LLM_BASE_URL``, ``JUNO_SHROUD_BASE_URL``, or ``SHROUD_OPENAI_BASE_URL``."
+        ),
+    )
+    juno_shroud_provider: str = Field(
+        default="openai",
+        validation_alias=AliasChoices("JUNO_SHROUD_PROVIDER", "SHROUD_PROVIDER"),
+        description=(
+            "Shroud upstream provider header value, such as ``openai``, ``anthropic``, "
+            "or ``google``; env ``JUNO_SHROUD_PROVIDER`` or ``SHROUD_PROVIDER``."
+        ),
+    )
+    juno_shroud_agent_key_env: str = Field(
+        default="JUNO_SHROUD_AGENT_KEY",
+        validation_alias=AliasChoices("JUNO_SHROUD_AGENT_KEY_ENV", "SHROUD_AGENT_KEY_ENV"),
+        description=(
+            "Name of the process environment variable that holds ``agent_id:ocv_...``; "
+            "settings never embed the secret. Env ``JUNO_SHROUD_AGENT_KEY_ENV`` or "
+            "``SHROUD_AGENT_KEY_ENV``."
+        ),
+    )
+    juno_shroud_model_header: bool = Field(
+        default=True,
+        validation_alias=AliasChoices("JUNO_SHROUD_MODEL_HEADER", "SHROUD_MODEL_HEADER"),
+        description=(
+            "If true, attach the active model id as ``X-Shroud-Model`` on Shroud requests; "
+            "env ``JUNO_SHROUD_MODEL_HEADER`` or ``SHROUD_MODEL_HEADER``."
+        ),
+    )

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -136,7 +136,7 @@ def test_shroud_mode_strips_agent_key_base_url_and_provider(monkeypatch) -> None
     s = Settings.model_construct(
         juno_use_shroud=True,
         juno_llm_base_url="  https://shroud.example/v1  ",
-        juno_shroud_provider="  anthropic  ",
+        juno_shroud_provider="  google  ",
         juno_shroud_agent_key_env="STRIP_SHROUD_KEY",
         juno_shroud_model_header=False,
         openai_model="  gpt-4o  ",
@@ -146,4 +146,4 @@ def test_shroud_mode_strips_agent_key_base_url_and_provider(monkeypatch) -> None
     assert model.openai_api_base == "https://shroud.example/v1"
     assert model.model_name == "gpt-4o"
     assert model.default_headers["X-Shroud-Agent-Key"] == "secret"
-    assert model.default_headers["X-Shroud-Provider"] == "anthropic"
+    assert model.default_headers["X-Shroud-Provider"] == "google"

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -17,6 +17,13 @@ def test_standard_mode_returns_model_string() -> None:
     assert build_agent_chat_model(s) == "openai:gpt-4o-mini"
 
 
+def test_default_settings_imply_shroud_off_and_preserve_model_string() -> None:
+    """Backwards compatible: Shroud defaults off; model path is the raw Settings.openai_model."""
+    s = Settings.model_construct(openai_model="openai:gpt-4o-mini")
+    assert s.juno_use_shroud is False
+    assert build_agent_chat_model(s) == "openai:gpt-4o-mini"
+
+
 def test_shroud_mode_builds_chat_openai_with_headers(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     monkeypatch.setenv("TEST_SHROUD_AGENT_KEY", "agent:stub")
 
@@ -62,3 +69,81 @@ def test_shroud_mode_raises_when_agent_key_missing(monkeypatch) -> None:  # type
     with pytest.raises(ValueError, match="MISSING_SHROUD_KEY") as excinfo:
         build_agent_chat_model(s)
     assert "ocv_" not in str(excinfo.value)
+
+
+def test_shroud_mode_raises_when_agent_key_env_name_empty() -> None:
+    s = Settings.model_construct(
+        juno_use_shroud=True,
+        juno_shroud_agent_key_env="",
+        openai_model="openai:gpt-4o-mini",
+    )
+    with pytest.raises(ValueError, match="juno_shroud_agent_key_env is empty"):
+        build_agent_chat_model(s)
+
+
+def test_shroud_mode_raises_when_agent_key_env_name_whitespace_only() -> None:
+    s = Settings.model_construct(
+        juno_use_shroud=True,
+        juno_shroud_agent_key_env="   \t",
+        openai_model="openai:gpt-4o-mini",
+    )
+    with pytest.raises(ValueError, match="juno_shroud_agent_key_env is empty"):
+        build_agent_chat_model(s)
+
+
+def test_shroud_mode_raises_when_base_url_empty(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("SHROUD_KEY_FOR_URL_TEST", "agent:stub")
+
+    s = Settings.model_construct(
+        juno_use_shroud=True,
+        juno_llm_base_url="",
+        juno_shroud_agent_key_env="SHROUD_KEY_FOR_URL_TEST",
+        openai_model="openai:gpt-4o-mini",
+    )
+    with pytest.raises(ValueError, match="juno_llm_base_url is empty"):
+        build_agent_chat_model(s)
+
+
+def test_shroud_mode_raises_when_base_url_whitespace_only(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("SHROUD_KEY_FOR_URL_TEST", "agent:stub")
+
+    s = Settings.model_construct(
+        juno_use_shroud=True,
+        juno_llm_base_url="  \n",
+        juno_shroud_agent_key_env="SHROUD_KEY_FOR_URL_TEST",
+        openai_model="openai:gpt-4o-mini",
+    )
+    with pytest.raises(ValueError, match="juno_llm_base_url is empty"):
+        build_agent_chat_model(s)
+
+
+def test_shroud_mode_raises_when_agent_key_env_value_whitespace_only(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("WS_ONLY_SHROUD_KEY", "  \t  ")
+
+    s = Settings.model_construct(
+        juno_use_shroud=True,
+        juno_shroud_agent_key_env="WS_ONLY_SHROUD_KEY",
+        juno_llm_base_url="https://shroud.example/v1",
+        openai_model="openai:gpt-4o-mini",
+    )
+    with pytest.raises(ValueError, match="WS_ONLY_SHROUD_KEY"):
+        build_agent_chat_model(s)
+
+
+def test_shroud_mode_strips_agent_key_base_url_and_provider(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("STRIP_SHROUD_KEY", "  secret  ")
+
+    s = Settings.model_construct(
+        juno_use_shroud=True,
+        juno_llm_base_url="  https://shroud.example/v1  ",
+        juno_shroud_provider="  anthropic  ",
+        juno_shroud_agent_key_env="STRIP_SHROUD_KEY",
+        juno_shroud_model_header=False,
+        openai_model="  gpt-4o  ",
+    )
+    model = build_agent_chat_model(s)
+    assert isinstance(model, ChatOpenAI)
+    assert model.openai_api_base == "https://shroud.example/v1"
+    assert model.model_name == "gpt-4o"
+    assert model.default_headers["X-Shroud-Agent-Key"] == "secret"
+    assert model.default_headers["X-Shroud-Provider"] == "anthropic"

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -1,0 +1,64 @@
+"""Tests for :mod:`juno.llm.factory`."""
+
+from __future__ import annotations
+
+import pytest
+from langchain_openai import ChatOpenAI
+
+from juno.llm.factory import build_agent_chat_model
+from juno.settings import Settings
+
+
+def test_standard_mode_returns_model_string() -> None:
+    s = Settings.model_construct(
+        juno_use_shroud=False,
+        openai_model="openai:gpt-4o-mini",
+    )
+    assert build_agent_chat_model(s) == "openai:gpt-4o-mini"
+
+
+def test_shroud_mode_builds_chat_openai_with_headers(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("TEST_SHROUD_AGENT_KEY", "agent:stub")
+
+    s = Settings.model_construct(
+        juno_use_shroud=True,
+        juno_llm_base_url="https://shroud.example/v1",
+        juno_shroud_provider="openai",
+        juno_shroud_agent_key_env="TEST_SHROUD_AGENT_KEY",
+        juno_shroud_model_header=True,
+        openai_model="openai:gpt-4o-mini",
+    )
+    model = build_agent_chat_model(s)
+    assert isinstance(model, ChatOpenAI)
+    assert model.openai_api_base == "https://shroud.example/v1"
+    assert model.model_name == "gpt-4o-mini"
+    assert model.default_headers["X-Shroud-Agent-Key"] == "agent:stub"
+    assert model.default_headers["X-Shroud-Provider"] == "openai"
+    assert model.default_headers["X-Shroud-Model"] == "gpt-4o-mini"
+
+
+def test_shroud_mode_omits_model_header_when_disabled(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("TEST_SHROUD_AGENT_KEY", "k")
+
+    s = Settings.model_construct(
+        juno_use_shroud=True,
+        juno_shroud_model_header=False,
+        juno_shroud_agent_key_env="TEST_SHROUD_AGENT_KEY",
+        openai_model="gpt-5",
+    )
+    model = build_agent_chat_model(s)
+    assert isinstance(model, ChatOpenAI)
+    assert "X-Shroud-Model" not in model.default_headers
+
+
+def test_shroud_mode_raises_when_agent_key_missing(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("MISSING_SHROUD_KEY", raising=False)
+
+    s = Settings.model_construct(
+        juno_use_shroud=True,
+        juno_shroud_agent_key_env="MISSING_SHROUD_KEY",
+        openai_model="openai:gpt-4o-mini",
+    )
+    with pytest.raises(ValueError, match="MISSING_SHROUD_KEY") as excinfo:
+        build_agent_chat_model(s)
+    assert "ocv_" not in str(excinfo.value)

--- a/tests/test_runtime_factory.py
+++ b/tests/test_runtime_factory.py
@@ -86,3 +86,23 @@ def test_build_supervisor_bundle_resolves_agent_model_once(tmp_path) -> None:
     mock_model.assert_called_once_with(s)
     assert mock_sub.call_args.kwargs["model"] is sentinel
     assert mock_sup.call_args.kwargs["model"] is sentinel
+
+
+def test_build_subagent_specs_skips_model_factory_when_model_provided(tmp_path) -> None:
+    """Explicit agent_model must be reused (single build in bundle path)."""
+    import shutil
+
+    repo_assistants = Path(__file__).resolve().parents[1] / "assistants"
+    shutil.copytree(repo_assistants, tmp_path / "assistants")
+    s = Settings(
+        mercury_base_url="https://m.test",
+        juno_assistants_dir=tmp_path / "assistants",
+        juno_supervisor_prompt_path=Path(__file__).resolve().parents[1] / "config" / "juno.supervisor.md",
+    )
+    sentinel = object()
+    with patch("juno.runtime.factory.build_agent_chat_model") as mock_model:
+        with patch("juno.runtime.factory.build_mercury_subagent") as mock_sub:
+            mock_sub.return_value = MagicMock(name="subagent")
+            build_subagent_specs(s, agent_model=sentinel)
+    mock_model.assert_not_called()
+    assert mock_sub.call_args.kwargs["model"] is sentinel

--- a/tests/test_runtime_factory.py
+++ b/tests/test_runtime_factory.py
@@ -64,3 +64,25 @@ def test_build_supervisor_bundle_includes_wallet_approval_tool_names(tmp_path) -
             bundle = build_supervisor_bundle(s)
     assert bundle.graph is fake_graph
     assert bundle.wallet_approval_supervisor_tool_names == frozenset({"mercury"})
+
+
+def test_build_supervisor_bundle_resolves_agent_model_once(tmp_path) -> None:
+    import shutil
+
+    repo_assistants = Path(__file__).resolve().parents[1] / "assistants"
+    shutil.copytree(repo_assistants, tmp_path / "assistants")
+    s = Settings(
+        mercury_base_url="https://m.test",
+        juno_assistants_dir=tmp_path / "assistants",
+        juno_supervisor_prompt_path=Path(__file__).resolve().parents[1] / "config" / "juno.supervisor.md",
+    )
+    sentinel = object()
+    fake_graph = MagicMock(name="compiled_graph")
+    with patch("juno.runtime.factory.build_agent_chat_model", return_value=sentinel) as mock_model:
+        with patch("juno.runtime.factory.build_mercury_subagent") as mock_sub:
+            mock_sub.return_value = MagicMock(name="subagent")
+            with patch("juno.runtime.factory.build_supervisor", return_value=fake_graph) as mock_sup:
+                build_supervisor_bundle(s)
+    mock_model.assert_called_once_with(s)
+    assert mock_sub.call_args.kwargs["model"] is sentinel
+    assert mock_sup.call_args.kwargs["model"] is sentinel

--- a/tests/test_runtime_factory.py
+++ b/tests/test_runtime_factory.py
@@ -16,6 +16,21 @@ from juno.runtime.factory import (
 from juno.settings import Settings
 
 
+@pytest.fixture(autouse=True)
+def disable_shroud_for_settings_construction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make `Settings()` deterministic in tests even if a local `.env` enables Shroud."""
+
+    monkeypatch.setenv("JUNO_USE_SHROUD", "false")
+    for key in (
+        "JUNO_SHROUD_ENABLED",
+        "SHROUD_ENABLED",
+        "JUNO_SHROUD_AGENT_KEY",
+        "JUNO_SHROUD_AGENT_KEY_ENV",
+        "SHROUD_AGENT_KEY_ENV",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
 def test_resolve_assistant_base_url_prefers_manifest_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MERCURY_BASE_URL", "https://from-env.test")
     m = AssistantManifest(runner="mercury", base_url_env="MERCURY_BASE_URL", system_prompt="")


### PR DESCRIPTION
## Summary
- Add Shroud runtime settings and a centralized Juno chat model factory.
- Route both Juno supervisor and Mercury subagent LLM calls through the same Shroud-aware model when enabled.
- Document vault-resolved provider setup and clarify that Juno-to-Mercury HTTP remains direct.

## Test plan
- `uv run pytest`
- `uv run python -m compileall -q src/juno`
- `git diff --check main...HEAD`
- IDE diagnostics via Cursor: no linter errors

## Notes
- `uv run ruff check .` and `uv run ruff format --check .` could not run because `ruff` is not installed in this project environment.