### PR TITLE
Add Postgres-backed supervisor checkpointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Relevant concepts and APIs:
    - Copy `config/juno.identity.yaml.example` to `config/juno.identity.yaml` and edit as needed
    - Optionally edit `config/juno.supervisor.md` (general supervisor behavior; concrete tool names and descriptions are appended automatically at startup)
    - Set environment variables (see below), including `MERCURY_BASE_URL` pointing at Mercury
+   - Optional: set `JUNO_CHECKPOINTER_DATABASE_URL` for Postgres-backed supervisor checkpoints (see below); if unset, the supervisor uses an in-memory saver (fine for dev; state is lost on restart)
 
 ## Environment variables
 
@@ -69,8 +70,25 @@ Relevant concepts and APIs:
 | `JUNO_SUPERVISOR_PROMPT_PATH` | Override path to the supervisor Markdown prompt (default: `config/juno.supervisor.md` under the working directory) |
 | `JUNO_USE_STREAM` | If set truthy, sends periodic typing while the supervisor runs |
 | `JUNO_LONGTERM_MEMORY_DIR` | Per-user long-term memory JSON directory; defaults to `data/juno_long_term_memory` under the process working directory |
+| `JUNO_CHECKPOINTER_DATABASE_URL` | PostgreSQL DSN for LangGraph supervisor checkpoints; empty uses the in-memory fallback (non-persistent). See **Supervisor checkpoints** |
 
 Optional: `.env` in the project root is loaded into the process environment at bot startup (`load_dotenv`) so provider SDKs (Groq, OpenAI, etc.) see keys like `GROQ_API_KEY`; Pydantic Settings also reads the same file for app fields.
+
+### Supervisor checkpoints (optional)
+
+- **DSN** — Standard libpq URI, e.g. `postgresql://USER:PASSWORD@HOST:5432/DBNAME` (query params such as `sslmode=require` are supported).
+- **TLS** — For hosted Postgres, prefer `sslmode=require` (or `verify-full` when you have CA material) in the URL rather than plaintext connections.
+- **Credentials** — Use a dedicated DB role with minimal privileges (only what LangGraph’s Postgres saver needs for its tables/migrations). Do **not** reuse superuser or application roles that own unrelated data.
+- **Secrets** — Treat the DSN like a password: never log it, avoid echoing env in shell history for production values, and do not commit `.env` or URLs containing credentials.
+- **Unset** — If `JUNO_CHECKPOINTER_DATABASE_URL` is unset or whitespace-only after trim, Juno uses `InMemorySaver` (no Postgres).
+
+Local Postgres without Compose:
+
+```bash
+docker run --rm -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:16
+```
+
+Then point Juno at `postgresql://postgres:postgres@127.0.0.1:5432/postgres` (create a dedicated database/user for real use).
 
 ## Run
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "langchain-openai",
     "langchain-groq",
     "python-telegram-bot>=21",
+    "langgraph-checkpoint-postgres",
+    "psycopg[binary,pool]",
 ]
 
 [dependency-groups]

--- a/src/juno/agents/build_supervisor.py
+++ b/src/juno/agents/build_supervisor.py
@@ -14,6 +14,7 @@ from langchain.tools import ToolRuntime, tool
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.tools import BaseTool
+from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.graph.state import CompiledStateGraph
 
@@ -158,6 +159,7 @@ def build_supervisor(
     supervisor_prompt_path: Path | None = None,
     system_prompt: str | None = None,
     inject_tools_context: bool = True,
+    checkpointer: BaseCheckpointSaver | None = None,
 ) -> CompiledStateGraph:
     """Build the top-level supervisor with checkpointed state and specialist tools.
 
@@ -195,7 +197,7 @@ def build_supervisor(
         model=model,
         tools=tools,
         system_prompt=prompt,
-        checkpointer=InMemorySaver(),
+        checkpointer=checkpointer if checkpointer is not None else InMemorySaver(),
         state_schema=CustomAgentState,
         middleware=memory_middleware,
     )

--- a/src/juno/runtime/checkpointer.py
+++ b/src/juno/runtime/checkpointer.py
@@ -1,0 +1,31 @@
+"""Supervisor checkpointer lifecycle: in-memory fallback or Postgres-backed saver."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.checkpoint.postgres import PostgresSaver
+
+from juno.settings import Settings
+
+
+@contextmanager
+def supervisor_checkpointer(settings: Settings) -> Iterator[BaseCheckpointSaver]:
+    """Open the configured checkpointer for the supervisor graph lifetime.
+
+    When ``juno_checkpointer_database_url`` is empty after stripping, yields
+    :class:`~langgraph.checkpoint.memory.InMemorySaver`. Otherwise opens
+    :class:`~langgraph.checkpoint.postgres.PostgresSaver` from the DSN, runs
+    ``setup()`` once, and yields the saver. The connection string is never logged
+    or returned from this helper.
+    """
+    url = settings.juno_checkpointer_database_url.strip()
+    if not url:
+        yield InMemorySaver()
+        return
+    with PostgresSaver.from_conn_string(url) as saver:
+        saver.setup()
+        yield saver

--- a/src/juno/runtime/factory.py
+++ b/src/juno/runtime/factory.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.graph.state import CompiledStateGraph
 
 from juno.agents import build_mercury_subagent, build_supervisor, default_mercury_subagent_spec
@@ -68,7 +69,10 @@ def build_subagent_specs(settings: Settings) -> list[SubagentSpec]:
     return [default_mercury_subagent_spec(sub)]
 
 
-def build_supervisor_bundle(settings: Settings) -> SupervisorBundle:
+def build_supervisor_bundle(
+    settings: Settings,
+    checkpointer: BaseCheckpointSaver | None = None,
+) -> SupervisorBundle:
     """Load manifests, build sub-agents and supervisor once; includes approval-ui metadata."""
     specs = build_subagent_specs(settings)
     graph = build_supervisor(
@@ -76,6 +80,7 @@ def build_supervisor_bundle(settings: Settings) -> SupervisorBundle:
         subagents=specs,
         supervisor_prompt_path=settings.juno_supervisor_prompt_path,
         long_term_memory_dir=settings.juno_long_term_memory_dir,
+        checkpointer=checkpointer,
     )
     return SupervisorBundle(
         graph=graph,

--- a/src/juno/settings.py
+++ b/src/juno/settings.py
@@ -69,3 +69,10 @@ class Settings(BaseSettings):
             "Default ``data/juno_long_term_memory`` relative to the process working directory."
         ),
     )
+    juno_checkpointer_database_url: str = Field(
+        default="",
+        description=(
+            "Secret-bearing PostgreSQL DSN for supervisor checkpoint persistence; env ``JUNO_CHECKPOINTER_DATABASE_URL``. "
+            "When empty, an in-memory checkpointer fallback is used."
+        ),
+    )

--- a/src/juno/telegram/bot.py
+++ b/src/juno/telegram/bot.py
@@ -11,6 +11,7 @@ from telegram.ext import Application, CallbackQueryHandler, CommandHandler, Mess
 
 from juno.identity import JunoIdentityNotFoundError, JunoIdentityValidationError, load_identity
 from juno.logging_config import configure_logging
+from juno.runtime.checkpointer import supervisor_checkpointer
 from juno.runtime.factory import build_supervisor_bundle
 from juno.settings import Settings
 from juno.telegram.handlers import (
@@ -62,28 +63,29 @@ async def run_bot(settings: Settings | None = None) -> None:
 
     logger.info("Loaded identity agent_id=%s display_name=%s", identity.agent_id, identity.display_name)
 
-    bundle = build_supervisor_bundle(settings)
-    application = Application.builder().token(settings.telegram_bot_token.strip()).build()
-    application.bot_data["supervisor"] = bundle.graph
-    application.bot_data["wallet_approval_supervisor_tools"] = bundle.wallet_approval_supervisor_tool_names
-    application.bot_data["settings"] = settings
+    with supervisor_checkpointer(settings) as cp:
+        bundle = build_supervisor_bundle(settings, checkpointer=cp)
+        application = Application.builder().token(settings.telegram_bot_token.strip()).build()
+        application.bot_data["supervisor"] = bundle.graph
+        application.bot_data["wallet_approval_supervisor_tools"] = bundle.wallet_approval_supervisor_tool_names
+        application.bot_data["settings"] = settings
 
-    application.add_handler(CommandHandler("start", cmd_start))
-    application.add_handler(CommandHandler("chain", cmd_chain))
-    application.add_handler(CommandHandler("wallet", cmd_wallet))
-    application.add_handler(CommandHandler("session", cmd_session))
-    application.add_handler(CommandHandler("session_clear", cmd_session_clear))
-    application.add_handler(CallbackQueryHandler(handle_approval_callback, pattern=r"^apr:"))
-    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
+        application.add_handler(CommandHandler("start", cmd_start))
+        application.add_handler(CommandHandler("chain", cmd_chain))
+        application.add_handler(CommandHandler("wallet", cmd_wallet))
+        application.add_handler(CommandHandler("session", cmd_session))
+        application.add_handler(CommandHandler("session_clear", cmd_session_clear))
+        application.add_handler(CallbackQueryHandler(handle_approval_callback, pattern=r"^apr:"))
+        application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
 
-    async with application:
-        await application.start()
-        await application.updater.start_polling(allowed_updates=Update.ALL_TYPES)
-        try:
-            await _wait_for_shutdown()
-        finally:
-            await application.updater.stop()
-            await application.stop()
+        async with application:
+            await application.start()
+            await application.updater.start_polling(allowed_updates=Update.ALL_TYPES)
+            try:
+                await _wait_for_shutdown()
+            finally:
+                await application.updater.stop()
+                await application.stop()
 
 
 def main() -> None:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import json
 import uuid
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import InMemorySaver
 
 from juno.agents import build_mercury_subagent, build_supervisor, default_mercury_subagent_spec
 from juno.agents.registry import SubagentSpec
@@ -252,6 +254,50 @@ def test_build_supervisor_rejects_duplicate_subagent_names() -> None:
             subagents=(dup, dup),
             supervisor_prompt_path=_SUPERVISOR_PROMPT_PATH,
         )
+
+
+def test_build_supervisor_passes_injected_checkpointer_to_create_agent() -> None:
+    model = FakeMessagesListChatModelWithTools(responses=[AIMessage(content="done")])
+    manifest = AssistantManifest(runner="mercury", base_url_env="X", system_prompt="S")
+    runner = MercuryAssistantRunner(
+        "https://unused.test",
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={"agent_reply": "ok"})),
+        http_path="/v1/agent",
+        request_body_mode="flat",
+    )
+    sub = build_mercury_subagent(model=model, manifest=manifest, runner=runner)
+    injected = InMemorySaver()
+    fake_graph = MagicMock()
+    with patch("juno.agents.build_supervisor.create_agent", return_value=fake_graph) as mock_create:
+        graph = build_supervisor(
+            model=model,
+            subagents=(default_mercury_subagent_spec(sub),),
+            supervisor_prompt_path=_SUPERVISOR_PROMPT_PATH,
+            checkpointer=injected,
+        )
+    assert graph is fake_graph
+    assert mock_create.call_args.kwargs["checkpointer"] is injected
+
+
+def test_build_supervisor_defaults_checkpointer_to_in_memory_saver() -> None:
+    model = FakeMessagesListChatModelWithTools(responses=[AIMessage(content="done")])
+    manifest = AssistantManifest(runner="mercury", base_url_env="X", system_prompt="S")
+    runner = MercuryAssistantRunner(
+        "https://unused.test",
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={"agent_reply": "ok"})),
+        http_path="/v1/agent",
+        request_body_mode="flat",
+    )
+    sub = build_mercury_subagent(model=model, manifest=manifest, runner=runner)
+    fake_graph = MagicMock()
+    with patch("juno.agents.build_supervisor.create_agent", return_value=fake_graph) as mock_create:
+        build_supervisor(
+            model=model,
+            subagents=(default_mercury_subagent_spec(sub),),
+            supervisor_prompt_path=_SUPERVISOR_PROMPT_PATH,
+        )
+    cp = mock_create.call_args.kwargs["checkpointer"]
+    assert isinstance(cp, InMemorySaver)
 
 
 def test_build_supervisor_multiple_distinct_specs() -> None:

--- a/tests/test_runtime_checkpointer.py
+++ b/tests/test_runtime_checkpointer.py
@@ -1,0 +1,42 @@
+"""Supervisor checkpointer: in-memory fallback and Postgres saver lifecycle."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from langgraph.checkpoint.memory import InMemorySaver
+
+from juno.runtime.checkpointer import supervisor_checkpointer
+from juno.settings import Settings
+
+
+def test_supervisor_checkpointer_empty_url_yields_in_memory() -> None:
+    s = Settings(juno_checkpointer_database_url="")
+    with supervisor_checkpointer(s) as cp:
+        assert isinstance(cp, InMemorySaver)
+
+
+def test_supervisor_checkpointer_whitespace_only_yields_in_memory() -> None:
+    s = Settings(juno_checkpointer_database_url="   \t  ")
+    with supervisor_checkpointer(s) as cp:
+        assert isinstance(cp, InMemorySaver)
+
+
+def test_supervisor_checkpointer_postgres_opens_setup_and_closes() -> None:
+    raw = "  postgresql://u:p@db.example:5432/app  "
+    stripped = raw.strip()
+    mock_saver = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = mock_saver
+    mock_ctx.__exit__.return_value = None
+
+    with patch("juno.runtime.checkpointer.PostgresSaver") as MockPG:
+        MockPG.from_conn_string.return_value = mock_ctx
+        s = Settings(juno_checkpointer_database_url=raw)
+        with supervisor_checkpointer(s) as cp:
+            assert cp is mock_saver
+            mock_saver.setup.assert_called_once()
+
+        MockPG.from_conn_string.assert_called_once_with(stripped)
+        mock_ctx.__enter__.assert_called_once()
+        mock_ctx.__exit__.assert_called_once()

--- a/tests/test_runtime_factory.py
+++ b/tests/test_runtime_factory.py
@@ -60,7 +60,28 @@ def test_build_supervisor_bundle_includes_wallet_approval_tool_names(tmp_path) -
     fake_graph = MagicMock(name="compiled_graph")
     with patch("juno.runtime.factory.build_mercury_subagent") as mock_build:
         mock_build.return_value = MagicMock(name="subagent")
-        with patch("juno.runtime.factory.build_supervisor", return_value=fake_graph):
+        with patch("juno.runtime.factory.build_supervisor", return_value=fake_graph) as mock_supervisor:
             bundle = build_supervisor_bundle(s)
     assert bundle.graph is fake_graph
     assert bundle.wallet_approval_supervisor_tool_names == frozenset({"mercury"})
+    assert mock_supervisor.call_args.kwargs.get("checkpointer") is None
+
+
+def test_build_supervisor_bundle_forwards_injected_checkpointer(tmp_path) -> None:
+    import shutil
+
+    repo_assistants = Path(__file__).resolve().parents[1] / "assistants"
+    shutil.copytree(repo_assistants, tmp_path / "assistants")
+    s = Settings(
+        mercury_base_url="https://m.test",
+        juno_assistants_dir=tmp_path / "assistants",
+        juno_supervisor_prompt_path=Path(__file__).resolve().parents[1] / "config" / "juno.supervisor.md",
+    )
+    fake_graph = MagicMock(name="compiled_graph")
+    fake_cp = MagicMock(name="checkpointer")
+    with patch("juno.runtime.factory.build_mercury_subagent") as mock_build:
+        mock_build.return_value = MagicMock(name="subagent")
+        with patch("juno.runtime.factory.build_supervisor", return_value=fake_graph) as mock_supervisor:
+            bundle = build_supervisor_bundle(s, checkpointer=fake_cp)
+    assert bundle.graph is fake_graph
+    assert mock_supervisor.call_args.kwargs["checkpointer"] is fake_cp

--- a/uv.lock
+++ b/uv.lock
@@ -303,7 +303,9 @@ dependencies = [
     { name = "langchain-groq" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "langgraph-checkpoint-postgres" },
     { name = "langsmith" },
+    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -325,7 +327,9 @@ requires-dist = [
     { name = "langchain-groq" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "langgraph-checkpoint-postgres" },
     { name = "langsmith", specifier = ">=0.7" },
+    { name = "psycopg", extras = ["binary", "pool"] },
     { name = "pydantic", specifier = ">=2" },
     { name = "pydantic-settings" },
     { name = "python-dotenv", specifier = ">=1" },
@@ -441,6 +445,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/e1/885e49cdafceb4c74dae4573bc5dd6054c6c640382ee73104532f33dca46/langgraph_checkpoint-4.0.3.tar.gz", hash = "sha256:a7b5e2ca18fb79b55edf19396d4ee446f8a53dcb7a4ec62ce6f1c7e00bb5af7f", size = 174009, upload-time = "2026-04-27T14:34:02.777Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/ee/ecd3fa2e893746dde3b768daca2a4935208bc77d09445437ccfffb4a8c9b/langgraph_checkpoint-4.0.3-py3-none-any.whl", hash = "sha256:b91b765712a2311a5b198760f714b7ab9b376d01c047ed78d9b9a3e80df802a3", size = 51682, upload-time = "2026-04-27T14:34:01.51Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint-postgres"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langgraph-checkpoint" },
+    { name = "orjson" },
+    { name = "psycopg" },
+    { name = "psycopg-pool" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/7a/8f439966643d32111248a225e6cb33a182d07c90de780c4dbfc1e0377832/langgraph_checkpoint_postgres-3.0.5.tar.gz", hash = "sha256:a8fd7278a63f4f849b5cbc7884a15ca8f41e7d5f7467d0a66b31e8c24492f7eb", size = 127856, upload-time = "2026-03-18T21:25:29.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/87/b0f98b33a67204bca9d5619bcd9574222f6b025cf3c125eedcec9a50ecbc/langgraph_checkpoint_postgres-3.0.5-py3-none-any.whl", hash = "sha256:86d7040a88fd70087eaafb72251d796696a0a2d856168f5c11ef620771411552", size = 42907, upload-time = "2026-03-18T21:25:28.75Z" },
 ]
 
 [[package]]
@@ -637,6 +656,79 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+pool = [
+    { name = "psycopg-pool" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]
@@ -1073,6 +1165,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add optional `JUNO_CHECKPOINTER_DATABASE_URL` support with PostgresSaver lifecycle for the Juno supervisor.
- Keep in-memory checkpointing as the default fallback when no URL is configured.
- Document DB auth/TLS guidance and add unit coverage for checkpointer injection and lifecycle selection.

## Test plan
- `uv run pytest`
- `uv sync --frozen`
- Cursor lint diagnostics for `src/juno` and `tests`

## Notes
- Normal CI does not require Postgres; Postgres behavior is covered with mocks.
- Real persistence across restart still needs manual verification with a configured database URL.