### PR TITLE
Telegram: progress banner, MarkdownV2 replies, approval keyboard gating

### DIFF
--- a/src/juno/telegram/formatting.py
+++ b/src/juno/telegram/formatting.py
@@ -1,0 +1,319 @@
+"""Telegram formatting: MarkdownV2 escaping, Markdown-like → HTML for model output, wrappers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from telegram import Bot, Message
+from telegram.constants import ParseMode
+from telegram.error import BadRequest
+
+# Characters that must be escaped outside of explicit MarkdownV2 spans.
+# https://core.telegram.org/bots/api#markdownv2-style
+_MD_V2_ESCAPE_CHARS = r"_*[]()~`>#+-=|{}.!"
+
+
+TELEGRAM_MAX_MESSAGE_LENGTH_CHARS = 4096
+
+
+def clip_for_telegram(text: str) -> str:
+    """Trim to Telegram's max message length; append ellipsis when clipped."""
+    if len(text) <= TELEGRAM_MAX_MESSAGE_LENGTH_CHARS:
+        return text
+    return text[: TELEGRAM_MAX_MESSAGE_LENGTH_CHARS - 1] + "…"
+
+
+def escape_telegram_html(text: str) -> str:
+    """Escape ``&``, ``<``, ``>`` so text is safe inside Telegram HTML parse mode."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+_MODEL_BOLD_PAIR = re.compile(r"\*\*(.+?)\*\*", flags=re.DOTALL)
+_ATX_HEADING_LINE = re.compile(r"(?m)^#{1,6}\s+(.*)$")
+
+
+def _plain_model_segment_to_html(plain: str) -> str:
+    """Normalize common Markdown-ish lines → Telegram HTML text (no structural tags).
+
+    Stripped ATX ``# headings``, hyphen bullets become ``•`` for readability; then HTML escapes.
+    """
+    promoted = plain
+    promoted = _ATX_HEADING_LINE.sub(r"\1", promoted)
+    promoted = re.sub(r"(^|\n)(\s*)-\s+", r"\1\2• ", promoted)
+    return escape_telegram_html(promoted)
+
+
+def model_markdown_like_to_telegram_html(text: str) -> str:
+    """Map subsets of model Markdown-ish output to Telegram HTML.
+
+    Converts ``**bold**``, strips ATX heading markers, swaps ``- `` line bullets for ``•``,
+    escapes ``<>&``. Not a full Markdown implementation.
+    """
+    if not text:
+        return ""
+    out: list[str] = []
+    pos = 0
+    for match in _MODEL_BOLD_PAIR.finditer(text):
+        out.append(_plain_model_segment_to_html(text[pos : match.start()]))
+        out.append(f"<b>{escape_telegram_html(match.group(1))}</b>")
+        pos = match.end()
+    out.append(_plain_model_segment_to_html(text[pos:]))
+    return "".join(out)
+
+
+def escape_md_v2(text: str) -> str:
+    """Escape arbitrary user or model text so it is literal in MarkdownV2."""
+    text = text.replace("\\", r"\\")
+    for ch in _MD_V2_ESCAPE_CHARS:
+        text = text.replace(ch, "\\" + ch)
+    return text
+
+
+def bold_md_v2(text: str) -> str:
+    """Bold span: inner text is escaped, then wrapped in *...*."""
+    return f"*{escape_md_v2(text)}*"
+
+
+def italic_md_v2(text: str) -> str:
+    """Italic span: inner text is escaped, then wrapped in _..._."""
+    return f"_{escape_md_v2(text)}_"
+
+
+def inline_code_md_v2(text: str) -> str:
+    """Single backtick inline code; newlines stripped (inline code cannot span lines)."""
+    text = text.replace("\n", " ").replace("\r", "")
+    inner = text.replace("\\", r"\\").replace("`", r"\`")
+    return f"`{inner}`"
+
+
+async def reply_text_markdown_v2(message: Message, text: str, **kwargs: Any) -> Message:
+    """``message.reply_text`` with :attr:`telegram.constants.ParseMode.MARKDOWN_V2`."""
+    kwargs = {**kwargs, "parse_mode": ParseMode.MARKDOWN_V2}
+    return await message.reply_text(text, **kwargs)
+
+
+async def send_message_markdown_v2(
+    bot: Bot,
+    chat_id: int,
+    text: str,
+    **kwargs: Any,
+) -> Message:
+    """``bot.send_message`` with MarkdownV2."""
+    kwargs = {**kwargs, "parse_mode": ParseMode.MARKDOWN_V2}
+    return await bot.send_message(chat_id=chat_id, text=text, **kwargs)
+
+
+async def edit_message_text_markdown_v2(message: Message, text: str, **kwargs: Any) -> Message:
+    """``message.edit_text`` with MarkdownV2."""
+    kwargs = {**kwargs, "parse_mode": ParseMode.MARKDOWN_V2}
+    return await message.edit_text(text=text, **kwargs)
+
+
+async def bot_edit_message_text_markdown_v2(
+    bot: Bot,
+    chat_id: int,
+    message_id: int,
+    text: str,
+    **kwargs: Any,
+) -> Message:
+    """``bot.edit_message_text`` with MarkdownV2."""
+    kwargs = {**kwargs, "parse_mode": ParseMode.MARKDOWN_V2}
+    return await bot.edit_message_text(
+        chat_id=chat_id,
+        message_id=message_id,
+        text=text,
+        **kwargs,
+    )
+
+
+async def send_message_html(
+    bot: Bot,
+    chat_id: int,
+    text: str,
+    **kwargs: Any,
+) -> Message:
+    """``bot.send_message`` with Telegram HTML entities."""
+    kwargs = {**kwargs, "parse_mode": ParseMode.HTML}
+    return await bot.send_message(chat_id=chat_id, text=text, **kwargs)
+
+
+async def bot_edit_message_text_html(
+    bot: Bot,
+    chat_id: int,
+    message_id: int,
+    text: str,
+    **kwargs: Any,
+) -> Message:
+    kwargs = {**kwargs, "parse_mode": ParseMode.HTML}
+    return await bot.edit_message_text(
+        chat_id=chat_id,
+        message_id=message_id,
+        text=text,
+        **kwargs,
+    )
+
+
+async def reply_text_plain(message: Message, text: str, **kwargs: Any) -> Message:
+    """Force plain text (no parse mode), for fallbacks next to MarkdownV2 paths."""
+    kwargs = dict(kwargs)
+    kwargs["parse_mode"] = None
+    return await message.reply_text(text, **kwargs)
+
+
+async def send_message_plain(
+    bot: Bot,
+    chat_id: int,
+    text: str,
+    **kwargs: Any,
+) -> Message:
+    """``bot.send_message`` without parse mode."""
+    kwargs = dict(kwargs)
+    kwargs["parse_mode"] = None
+    return await bot.send_message(chat_id=chat_id, text=text, **kwargs)
+
+
+async def edit_message_text_plain(message: Message, text: str, **kwargs: Any) -> Message:
+    """``message.edit_text`` without parse mode."""
+    kwargs = dict(kwargs)
+    kwargs["parse_mode"] = None
+    return await message.edit_text(text=text, **kwargs)
+
+
+async def bot_edit_message_text_plain(
+    bot: Bot,
+    chat_id: int,
+    message_id: int,
+    text: str,
+    **kwargs: Any,
+) -> Message:
+    """``bot.edit_message_text`` without parse mode."""
+    kwargs = dict(kwargs)
+    kwargs["parse_mode"] = None
+    return await bot.edit_message_text(
+        chat_id=chat_id,
+        message_id=message_id,
+        text=text,
+        **kwargs,
+    )
+
+
+async def reply_user_text_markdown_v2_safe(message: Message, raw_text: str, **kwargs: Any) -> Message:
+    """Send ``raw_text`` escaped for MarkdownV2; fallback to plain on entity parse failure."""
+    try:
+        return await reply_text_markdown_v2(message, escape_md_v2(raw_text), **kwargs)
+    except BadRequest:
+        return await reply_text_plain(message, raw_text, **kwargs)
+
+
+async def send_user_text_markdown_v2_safe(
+    bot: Bot,
+    chat_id: int,
+    raw_text: str,
+    **kwargs: Any,
+) -> Message:
+    """Escapes ``raw_text`` for Telegram MarkdownV2, falling back to plain if parsing fails."""
+    try:
+        return await send_message_markdown_v2(
+            bot,
+            chat_id,
+            escape_md_v2(raw_text),
+            **kwargs,
+        )
+    except BadRequest:
+        return await send_message_plain(bot, chat_id, raw_text, **kwargs)
+
+
+async def send_assistant_reply_html_safe(
+    bot: Bot,
+    chat_id: int,
+    raw_text: str,
+    **kwargs: Any,
+) -> Message:
+    """Assistant / tool model text → Markdown-like subset as HTML; plain fallback."""
+    html_body = clip_for_telegram(model_markdown_like_to_telegram_html(raw_text))
+    plain_body = clip_for_telegram(raw_text)
+    try:
+        return await send_message_html(bot, chat_id, html_body, **kwargs)
+    except BadRequest:
+        return await send_message_plain(bot, chat_id, plain_body, **kwargs)
+
+
+async def bot_edit_assistant_reply_html_safe(
+    bot: Bot,
+    chat_id: int,
+    message_id: int,
+    raw_text: str,
+    **kwargs: Any,
+) -> Message:
+    html_body = clip_for_telegram(model_markdown_like_to_telegram_html(raw_text))
+    plain_body = clip_for_telegram(raw_text)
+    try:
+        return await bot_edit_message_text_html(
+            bot,
+            chat_id,
+            message_id,
+            html_body,
+            **kwargs,
+        )
+    except BadRequest:
+        return await bot_edit_message_text_plain(
+            bot,
+            chat_id,
+            message_id,
+            plain_body,
+            **kwargs,
+        )
+
+
+async def bot_edit_user_text_markdown_v2_safe(
+    bot: Bot,
+    chat_id: int,
+    message_id: int,
+    raw_text: str,
+    **kwargs: Any,
+) -> Message:
+    """Edit with escaped MarkdownV2; fallback to plain if parsing fails."""
+    try:
+        return await bot_edit_message_text_markdown_v2(
+            bot,
+            chat_id,
+            message_id,
+            escape_md_v2(raw_text),
+            **kwargs,
+        )
+    except BadRequest:
+        return await bot_edit_message_text_plain(
+            bot,
+            chat_id,
+            message_id,
+            raw_text,
+            **kwargs,
+        )
+
+
+__all__ = [
+    "TELEGRAM_MAX_MESSAGE_LENGTH_CHARS",
+    "bold_md_v2",
+    "bot_edit_assistant_reply_html_safe",
+    "bot_edit_message_text_html",
+    "bot_edit_message_text_markdown_v2",
+    "bot_edit_message_text_plain",
+    "bot_edit_user_text_markdown_v2_safe",
+    "clip_for_telegram",
+    "edit_message_text_markdown_v2",
+    "edit_message_text_plain",
+    "escape_md_v2",
+    "inline_code_md_v2",
+    "escape_telegram_html",
+    "italic_md_v2",
+    "model_markdown_like_to_telegram_html",
+    "reply_text_markdown_v2",
+    "reply_text_plain",
+    "reply_user_text_markdown_v2_safe",
+    "send_assistant_reply_html_safe",
+    "send_message_html",
+    "send_message_markdown_v2",
+    "send_message_plain",
+    "send_user_text_markdown_v2_safe",
+]

--- a/src/juno/telegram/handlers.py
+++ b/src/juno/telegram/handlers.py
@@ -8,6 +8,12 @@ from telegram.ext import ContextTypes
 
 from juno.telegram.approval_state import get_last_approval_token, set_pending_approval
 from juno.telegram.approval_ui import MERCURY_INLINE_CONTINUE_TEXT, approval_state_value
+from juno.telegram.formatting import (
+    escape_md_v2,
+    inline_code_md_v2,
+    reply_text_markdown_v2,
+    reply_user_text_markdown_v2_safe,
+)
 from juno.telegram.session import clear_chat_session, get_chat_session
 from juno.telegram.turn import execute_supervisor_turn
 
@@ -16,12 +22,15 @@ logger = logging.getLogger(__name__)
 
 async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if update.message:
-        await update.message.reply_text(
-            "Juno routes on-chain and account questions through Mercury (real backend data).\n\n"
-            "• Send any message to chat.\n"
-            "• Optional: /chain base (or ethereum, …) and /wallet 0x… so Mercury gets context.\n"
-            "• /session shows saved chain/wallet; /session_clear resets them.\n"
-            "• If wallet approval is required, tap Approve or Decline — Juno continues automatically.",
+        await reply_user_text_markdown_v2_safe(
+            update.message,
+            raw_text=(
+                "Juno routes on-chain and account questions through Mercury (real backend data).\n\n"
+                "• Send any message to chat.\n"
+                "• Optional: /chain base (or ethereum, …) and /wallet 0x… so Mercury gets context.\n"
+                "• /session shows saved chain/wallet; /session_clear resets them.\n"
+                "• If wallet approval is required, tap Approve or Decline — Juno continues automatically."
+            ),
         )
 
 
@@ -33,12 +42,20 @@ async def cmd_chain(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     sess = get_chat_session(context.application.bot_data, chat_id)
     if not args:
         cur = sess["chain"] or "not set"
-        await update.message.reply_text(
-            f"Current chain: `{cur}`.\nUsage: `/chain base` (or another network name).",
+        await reply_text_markdown_v2(
+            update.message,
+            escape_md_v2("Current chain: ")
+            + inline_code_md_v2(cur)
+            + escape_md_v2("\nUsage: /chain base (or another network name)."),
         )
         return
     sess["chain"] = " ".join(args).strip().lower()
-    await update.message.reply_text(f"Chain set to `{sess['chain']}`. Mercury will see this on the next message.")
+    await reply_text_markdown_v2(
+        update.message,
+        escape_md_v2("Chain set to ")
+        + inline_code_md_v2(sess["chain"])
+        + escape_md_v2(". Mercury will see it on the next message."),
+    )
 
 
 async def cmd_wallet(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -49,12 +66,18 @@ async def cmd_wallet(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     sess = get_chat_session(context.application.bot_data, chat_id)
     if not args:
         cur = sess["wallet_id"] or "not set"
-        await update.message.reply_text(
-            f"Current wallet: `{cur}`.\nUsage: `/wallet 0x…`",
+        await reply_text_markdown_v2(
+            update.message,
+            escape_md_v2("Current wallet: ")
+            + inline_code_md_v2(cur)
+            + escape_md_v2("\nUsage: /wallet 0x…"),
         )
         return
     sess["wallet_id"] = args[0].strip()
-    await update.message.reply_text("Wallet saved. Mercury will see it on the next message.")
+    await reply_user_text_markdown_v2_safe(
+        update.message,
+        raw_text="Wallet saved. Mercury will see it on the next message.",
+    )
 
 
 async def cmd_session(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -62,10 +85,13 @@ async def cmd_session(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         return
     chat_id = update.effective_chat.id
     sess = get_chat_session(context.application.bot_data, chat_id)
-    await update.message.reply_text(
-        "Session for this chat:\n"
-        f"• chain: `{sess['chain'] or '—'}`\n"
-        f"• wallet_id: `{sess['wallet_id'] or '—'}`",
+    await reply_text_markdown_v2(
+        update.message,
+        escape_md_v2("Session for this chat:\n")
+        + escape_md_v2("• chain: ")
+        + inline_code_md_v2(sess["chain"] or "—")
+        + escape_md_v2("\n• wallet_id: ")
+        + inline_code_md_v2(sess["wallet_id"] or "—"),
     )
 
 
@@ -74,7 +100,10 @@ async def cmd_session_clear(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         return
     chat_id = update.effective_chat.id
     clear_chat_session(context.application.bot_data, chat_id)
-    await update.message.reply_text("Session cleared (chain and wallet).")
+    await reply_user_text_markdown_v2_safe(
+        update.message,
+        raw_text="Session cleared (chain and wallet).",
+    )
 
 
 async def handle_approval_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/src/juno/telegram/turn.py
+++ b/src/juno/telegram/turn.py
@@ -26,6 +26,7 @@ from juno.telegram.approval_ui import (
     should_show_wallet_approval_keyboard,
 )
 from juno.telegram.errors import format_agent_error
+from juno.telegram.formatting import send_assistant_reply_html_safe
 from juno.telegram.messages import final_ai_content, messages_blob_for_approval
 from juno.telegram.parsing import extract_approval_correlation_id
 from juno.telegram.session import get_chat_session
@@ -143,9 +144,10 @@ async def execute_supervisor_turn(
                 chat_id,
                 trace_id,
             )
-            await application.bot.send_message(
+            await send_assistant_reply_html_safe(
+                application.bot,
                 chat_id=chat_id,
-                text=format_agent_error(exc),
+                raw_text=format_agent_error(exc),
                 reply_to_message_id=reply_to_message_id,
             )
             return
@@ -161,17 +163,19 @@ async def execute_supervisor_turn(
         set_last_approval_token(application.bot_data, chat_id, token)
         keyboard = mercury_approval_inline_keyboard()
         body = final_text if final_text.strip() else "Wallet approval required."
-        await application.bot.send_message(
+        await send_assistant_reply_html_safe(
+            application.bot,
             chat_id=chat_id,
-            text=body,
+            raw_text=body,
             reply_markup=keyboard,
             reply_to_message_id=reply_to_message_id,
         )
         return
 
-    await application.bot.send_message(
+    await send_assistant_reply_html_safe(
+        application.bot,
         chat_id=chat_id,
-        text=final_text if final_text.strip() else "(no reply)",
+        raw_text=final_text if final_text.strip() else "(no reply)",
         reply_to_message_id=reply_to_message_id,
     )
 

--- a/tests/test_telegram_formatting.py
+++ b/tests/test_telegram_formatting.py
@@ -1,0 +1,127 @@
+"""Tests for Telegram MarkdownV2 escaping and send/edit wrappers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+from telegram.constants import ParseMode
+from telegram.error import BadRequest
+
+from juno.telegram.formatting import (
+    bold_md_v2,
+    bot_edit_message_text_markdown_v2,
+    escape_md_v2,
+    inline_code_md_v2,
+    model_markdown_like_to_telegram_html,
+    reply_text_markdown_v2,
+    send_assistant_reply_html_safe,
+    send_message_markdown_v2,
+    send_user_text_markdown_v2_safe,
+)
+from juno.telegram.formatting import edit_message_text_markdown_v2 as edit_md_v2
+
+
+def test_escape_md_v2_escapes_specials() -> None:
+    assert escape_md_v2("! * _|`") == r"\! \* \_\|\`"
+
+
+def test_escape_md_v2_period_and_hyphen() -> None:
+    assert escape_md_v2("1.0-beta") == r"1\.0\-beta"
+
+
+def test_bold_md_v2_escapes_inner() -> None:
+    assert bold_md_v2("a*b") == r"*a\*b*"
+
+
+def test_inline_code_md_v2_backtick_and_slash() -> None:
+    assert inline_code_md_v2("a`b") == r"`a\`b`"
+    assert inline_code_md_v2(r"a\b") == r"`a\\b`"
+
+
+def test_inline_code_md_v2_strips_newlines() -> None:
+    assert inline_code_md_v2("a\nb") == "`a b`"
+
+
+@pytest.mark.asyncio
+async def test_reply_text_markdown_v2_forces_parse_mode() -> None:
+    message = MagicMock()
+    message.reply_text = AsyncMock(return_value=MagicMock())
+    await reply_text_markdown_v2(message, "x")
+    message.reply_text.assert_awaited_once_with("x", parse_mode=ParseMode.MARKDOWN_V2)
+
+
+@pytest.mark.asyncio
+async def test_send_message_markdown_v2_forces_parse_mode() -> None:
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=MagicMock())
+    await send_message_markdown_v2(bot, 1, "hi", disable_notification=True)
+    bot.send_message.assert_awaited_once_with(
+        chat_id=1,
+        text="hi",
+        disable_notification=True,
+        parse_mode=ParseMode.MARKDOWN_V2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_message_text_markdown_v2_forces_parse_mode() -> None:
+    message = MagicMock()
+    message.edit_text = AsyncMock(return_value=MagicMock())
+    await edit_md_v2(message, "y")
+    message.edit_text.assert_awaited_once_with(text="y", parse_mode=ParseMode.MARKDOWN_V2)
+
+
+def test_model_markdown_like_bold_and_hyphen_bullet() -> None:
+    html = model_markdown_like_to_telegram_html("**Ethereum**\n- 0.1 ETH")
+    assert "<b>Ethereum</b>" in html
+    assert "• 0.1 ETH" in html
+    assert "**" not in html
+
+
+def test_model_markdown_like_strips_atx_heading() -> None:
+    html = model_markdown_like_to_telegram_html("### Section\nbody")
+    assert "###" not in html
+    assert "Section" in html
+
+
+def test_model_markdown_escapes_angle_brackets_in_plain_text() -> None:
+    html = model_markdown_like_to_telegram_html("a < b & c")
+    assert "<" not in html or "&lt;" in html
+    assert "&lt;" in html
+
+
+@pytest.mark.asyncio
+async def test_send_assistant_reply_html_safe_sets_html_parse_mode() -> None:
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=MagicMock())
+    await send_assistant_reply_html_safe(bot, 7, "**hi**")
+    bot.send_message.assert_awaited_once()
+    kwargs = bot.send_message.await_args.kwargs
+    assert kwargs["parse_mode"] == ParseMode.HTML
+    assert "<b>hi</b>" in kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_send_user_text_markdown_v2_safe_falls_back_on_bad_request() -> None:
+    bot = MagicMock()
+    bot.send_message = AsyncMock(side_effect=[BadRequest("parse"), MagicMock()])
+    await send_user_text_markdown_v2_safe(bot, 1, "plain * ok")
+    assert bot.send_message.await_count == 2
+    first = bot.send_message.await_args_list[0]
+    assert first.kwargs["chat_id"] == 1 and first.kwargs["parse_mode"] == ParseMode.MARKDOWN_V2
+    second = bot.send_message.await_args_list[1]
+    assert second == call(chat_id=1, text="plain * ok", parse_mode=None)
+
+
+@pytest.mark.asyncio
+async def test_bot_edit_message_text_markdown_v2_forces_parse_mode() -> None:
+    bot = MagicMock()
+    bot.edit_message_text = AsyncMock(return_value=MagicMock())
+    await bot_edit_message_text_markdown_v2(bot, 2, 99, "z")
+    bot.edit_message_text.assert_awaited_once_with(
+        chat_id=2,
+        message_id=99,
+        text="z",
+        parse_mode=ParseMode.MARKDOWN_V2,
+    )


### PR DESCRIPTION
## Summary

- Progress updates while the supervisor runs when `JUNO_USE_STREAM` is enabled (MarkdownV2 banner; fallback to sync invoke on failure).
- Outgoing Telegram text uses MarkdownV2 with escaping and falls back to plain text on entity parse failures.
- Wallet Approve/Decline keyboard shows only when there is a structured marker or legacy tool approval phrasing plus a correlation id (not model narration alone).

## Closes on merge

- Closes #7
- Closes #8
- Closes #17

## Test plan

- `uv run pytest`